### PR TITLE
Fix makePropTypesAst require on camel case sensitive OS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var {$debug, getExportNameForType} = require('./util');
 var convertToPropTypes = require('./convertToPropTypes');
-var makePropTypesAst = require('./makePropTypesAst');
+var makePropTypesAst = require('./makePropTypesAST');
 
 var matchedPropTypes;
 


### PR DESCRIPTION
```
Error: Cannot find module './makePropTypesAst'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/home/travis/build/MoOx/js-boilerplate/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:102:24)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
```

See https://travis-ci.org/MoOx/js-boilerplate/builds/118446748#L269