### PR TITLE
Support instanceOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Foo.propTypes = {
   a_number: React.PropTypes.number.isRequired,
   a_generic_object: React.PropTypes.any.isRequired,
   array_of_strings: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-  instance_of_Bar: React.PropTypes.any.isRequired,
+  instance_of_Bar: React.PropTypes.instanceOf(Bar).isRequired,
   anything: React.PropTypes.any.isRequired,
   one_of: React.PropTypes.oneOf(['QUACK', 'BARK', 5]).isRequired,
   onw_of_type: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]).isRequired,

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -39,7 +39,7 @@ module.exports = function convertToPropTypes(node, typesToIdentifiers) {
       resultPropType = {type: 'raw', value: typesToIdentifiers[node.id.name]};
     }
     else {
-      resultPropType = {type: 'any'};
+      resultPropType = {type: 'instanceOf', of: node.id.name};
     }
   }
   else if (node.type === 'UnionTypeAnnotation') {

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -47,6 +47,12 @@ function makePropTypesAst(propTypeData) {
         [t.arrayExpression(data.options.map(makePropType))]
       )
     }
+    else if (method === 'instanceOf') {
+      node = t.callExpression(
+        t.memberExpression(node, t.identifier('instanceOf')),
+        [t.identifier(data.of)]
+      )
+    }
     else {
       console.error(PLUGIN_NAME + ': This is an internal error that should never happen. Report it immediately with the source file and babel config.', data);
       $debug('Unknown node ' + JSON.stringify(data, null, 2));


### PR DESCRIPTION
I noticed your older comment, which I'll quote here:

``` js
// FIXME: I'm not sure what to do here. We don't want to attempt to reference a constructor that's not
// in scope. One option would be to do PropTypes.shape({constructor: PropTypes.shape({name: 'Bar'})}).
```

I think this can be an issue if types are imported/exported, but otherwise when constructing a type definition, it is required that all references are in scope.

Since it is very seldom that Props types are constructed outside of the scope of the component itself, it should be safe, in my opinion, to make this transformation.
