### PR TITLE
Add void support.

### DIFF
--- a/src/__test__/fixtures/basic.input.js
+++ b/src/__test__/fixtures/basic.input.js
@@ -18,7 +18,8 @@ type FooProps = {
       },
       string_property_2: string,
     }
-  }
+  },
+  should_error_if_provided: void
 }
 
 export default class Foo extends React.Component {

--- a/src/__test__/fixtures/basic.output.js
+++ b/src/__test__/fixtures/basic.output.js
@@ -42,7 +42,10 @@ Foo.propTypes = {
       }).isRequired,
       string_property_2: React.PropTypes.string.isRequired
     }).isRequired
-  }).isRequired
+  }).isRequired,
+  should_error_if_provided: function should_error_if_provided(props, propName, componentName) {
+    if (props[propName] != null) return new Error('Invalid prop `' + propName + '` of value `' + value + '` passed to `' + componentName + '`. Expected undefined or null.');
+  }
 };
 exports.default = Foo;
 

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -27,6 +27,7 @@ module.exports = function convertToPropTypes(node, typesToIdentifiers) {
   else if (node.type === 'NumberTypeAnnotation') resultPropType = {type: 'number'};
   else if (node.type === 'StringTypeAnnotation') resultPropType = {type: 'string'};
   else if (node.type === 'BooleanTypeAnnotation') resultPropType = {type: 'bool'};
+  else if (node.type === 'VoidTypeAnnotation') resultPropType = {type: 'void'};
   else if (node.type === 'GenericTypeAnnotation') {
     if (node.id.name === 'Array') {
       resultPropType = {type: 'arrayOf', of: convertToPropTypes(node.typeParameters.params[0], typesToIdentifiers)};


### PR DESCRIPTION
So, this is a bit of a wildcard.

I've found it useful in some libraries I use to actually error out when a user provides a property I don't want them to set - perhaps as a way of deprecating props, or to discourage bad behavior.

I considered having it transform to `oneOf([null, undefined])`, but the error message is unclear:

> Warning: Failed propType: Invalid prop `foo` of value `bar` supplied to `Child`, expected one of [null,null]. Check the render method of `Parent`.

This function warns:

>Warning: Failed propType: Invalid prop `foo` of value `bar` passed to `Child`. Expected void. Check the render method of `Parent`.

See http://astexplorer.net/#/zZKFxnO2nA/2 for an example in action.