### PR TITLE
Minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-stage-1": "^6.5.0"
   },
   "dependencies": {
+    "babel-template": "^6.7.0",
     "babel-types": "^6.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-flow-react-proptypes",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "converts flow types to react proptypes",
   "main": "lib/index.js",
   "scripts": {

--- a/src/__test__/fixtures/function-types.input.js
+++ b/src/__test__/fixtures/function-types.input.js
@@ -7,7 +7,7 @@ type Props = {
   onClick?: () => void,
 }
 
-class MyComponent extends Component<void, Props, State> {
+class MyComponent extends Component<void, Props, void> {
 }
 
 export default MyComponent;


### PR DESCRIPTION
Two straightforward bug fixes.

```
$ git clone https://github.com/brigand/babel-plugin-flow-react-proptypes
$ cd babel-plugin-flow-react-proptypes
$ npm install && npm test
```

Currently yields a whole bunch of:

```
Prop types for src/__test__/fixtures/function-types.output.js:
Error: Cannot find module 'babel-template'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/marcus.armstrong/babel-plugin-flow-react-proptypes/lib/makePropTypesAst.js:14:22)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```

Additionally, running flow in a project using this plugin yields:

```
node_modules/babel-plugin-flow-react-proptypes/src/__test__/fixtures/function-types.input.js:10
 10: class MyComponent extends Component<void, Props, State> {
                                                      ^^^^^ identifier `State`. Could not resolve name
```

Commits attached fix both of these issues in the most straightforward way possible, and I've also attached a version bump for npm distribution. Happy to revise as needed, just let me know.