### PR TITLE
Bug fixes

### DIFF
--- a/src/__test__/fixtures/export-type-and-component.input.js
+++ b/src/__test__/fixtures/export-type-and-component.input.js
@@ -1,0 +1,17 @@
+// @flow
+
+import React from 'react';
+
+export type T = {
+  f: Function,
+  i: number,
+  x: 'foo' | 'baz',
+};
+
+const C = ({
+  f,
+}: T) => {
+   <div></div>
+};
+
+export default C;

--- a/src/__test__/fixtures/export-type-and-component.output.js
+++ b/src/__test__/fixtures/export-type-and-component.output.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+Object.defineProperty(module.exports, 'babelPluginFlowReactPropTypes_proptype_T', require('react').PropTypes.shape({
+  f: require('react').PropTypes.func.isRequired,
+  i: require('react').PropTypes.number.isRequired,
+  x: require('react').PropTypes.oneOf(['foo', 'baz']).isRequired
+}));
+
+
+var C = function C(_ref) {
+  var f = _ref.f;
+
+  _react2.default.createElement('div', null);
+};
+
+C.propTypes = {
+  f: require('react').PropTypes.func.isRequired,
+  i: require('react').PropTypes.number.isRequired,
+  x: require('react').PropTypes.oneOf(['foo', 'baz']).isRequired
+};
+exports.default = C;
+

--- a/src/__test__/fixtures/import-and-loops.input.js
+++ b/src/__test__/fixtures/import-and-loops.input.js
@@ -1,0 +1,27 @@
+// @flow
+
+import React from 'react';
+import type { ExternalType } from '../types';
+
+export type T = {
+    flag: boolean,
+    list: Array<ExternalType>,
+};
+
+const C = ({
+    flag,
+    list,
+}: T) => {
+    return flag
+        ? <div>yes</div>
+        : <Select>
+            {list.map((e: ExternalType) => {
+                return (
+                    <option value={e.id} key={e.id}>
+                    </option>
+                );
+            })}
+        </Select>;
+};
+
+export default C;

--- a/src/__test__/fixtures/import-and-loops.output.js
+++ b/src/__test__/fixtures/import-and-loops.output.js
@@ -1,0 +1,39 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var babelPluginFlowReactPropTypes_proptype_ExternalType = require('../types').babelPluginFlowReactPropTypes_proptype_ExternalType || require('react').PropTypes.any;
+
+Object.defineProperty(module.exports, 'babelPluginFlowReactPropTypes_proptype_T', require('react').PropTypes.shape({
+    flag: require('react').PropTypes.bool.isRequired,
+    list: require('react').PropTypes.arrayOf(babelPluginFlowReactPropTypes_proptype_ExternalType).isRequired
+}));
+
+
+var C = function C(_ref) {
+    var flag = _ref.flag;
+    var list = _ref.list;
+
+    return flag ? _react2.default.createElement(
+        'div',
+        null,
+        'yes'
+    ) : _react2.default.createElement(
+        Select,
+        null,
+        list.map(function (e) {
+            return _react2.default.createElement('option', { value: e.id, key: e.id });
+        })
+    );
+};
+
+exports.default = C;
+

--- a/src/__test__/fixtures/stateless-arrow.input.js
+++ b/src/__test__/fixtures/stateless-arrow.input.js
@@ -1,5 +1,7 @@
 var React = require('react');
 
+const arrowFunctionWithNoBody = () => window.console;
+
 type Choices = 'option1' | 'option2';
 
 type FooT = {

--- a/src/__test__/fixtures/stateless-arrow.output.js
+++ b/src/__test__/fixtures/stateless-arrow.output.js
@@ -5,6 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 var React = require('react');
 
+var arrowFunctionWithNoBody = function arrowFunctionWithNoBody() {
+  return window.console;
+};
+
 var Foo = function Foo(props) {
   React.createElement(
     'div',

--- a/src/__test__/fixtures/stateless-inline-imports.input.js
+++ b/src/__test__/fixtures/stateless-inline-imports.input.js
@@ -1,0 +1,8 @@
+// @flow
+
+import React from 'react';
+import type { T } from '../types';
+
+const C = (props: T) => {
+  <div>{props.name}</div>
+};

--- a/src/__test__/fixtures/stateless-inline-imports.output.js
+++ b/src/__test__/fixtures/stateless-inline-imports.output.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var babelPluginFlowReactPropTypes_proptype_T = require('../types').babelPluginFlowReactPropTypes_proptype_T || require('react').PropTypes.any;
+
+var C = function C(props) {
+  _react2.default.createElement(
+    'div',
+    null,
+    props.name
+  );
+};
+

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -61,6 +61,9 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     else if (node.id.name === 'Object') {
       resultPropType = {type: 'object'};
     }
+    else if (node.id.name === 'Function') {
+      resultPropType = {type: 'func'};
+    }
     else {
       resultPropType = {type: 'any'};
     }

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,14 @@ export default function flowReactPropTypes(babel) {
       throw new Error(`Did not find type annotation for ${name}`);
     }
 
+    if (!props.properties) {
+      // Bail out if we don't have any properties. This will be the case if
+      // we have an imported PropType, like:
+      // import type { T } from '../types';
+      // const C = (props: T) => <div>{props.name}</div>;
+      return;
+    }
+
     const propTypesAST = makePropTypesAst(props);
     const attachPropTypesAST = t.expressionStatement(
       t.assignmentExpression(

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,15 @@ export default function flowReactPropTypes(babel) {
 
   const isFunctionalReactComponent = path => {
     const bodyParts = path.node.body.body;
+    if (!bodyParts) {
+      return false;
+    }
+
+    if ((path.type === 'ArrowFunctionExpression' || path.type === 'FunctionExpression') && !path.parent.id) {
+      // Could be functions inside a React component
+      return false;
+    }
+
     for (let i = 0; i < bodyParts.length; i++) {
       const b = bodyParts[i];
       if (t.isExpressionStatement(b)) {


### PR DESCRIPTION
Hi @brigand 

I've found some issues while testing this out on a larger codebase:
- the detection for stateless components caught loops inside React components
- issues when we use types in a file where the types are also exported
- crash when finding arrow function `const arrowFunctionWithNoBody = () => window.console;`

Let me see if I can find some more issues. But I think we should release these a hotfix.