### PR TITLE
Better handling of UnionTypeAnnotation containing null

### DIFF
--- a/src/__test__/fixtures/stateless.input.js
+++ b/src/__test__/fixtures/stateless.input.js
@@ -2,6 +2,10 @@ var React = require('react');
 
 type T = {
   an_optional_string?: string,
+  an_optional_string_1: null | string,
+  an_optional_union?: 1 | 10 | 'foo',
+  an_optional_union_1: 1 | 10 | 'foo' | null,
+  an_optional_union_2: null | string | number,
   a_number: number,
   a_boolean: boolean,
   a_generic_object: Object,

--- a/src/__test__/fixtures/stateless.output.js
+++ b/src/__test__/fixtures/stateless.output.js
@@ -11,6 +11,10 @@ function Foo(props) {
 }
 Foo.propTypes = {
   an_optional_string: require('react').PropTypes.string,
+  an_optional_string_1: require('react').PropTypes.string,
+  an_optional_union: require('react').PropTypes.oneOf([1, 10, 'foo']),
+  an_optional_union_1: require('react').PropTypes.oneOf([1, 10, 'foo']),
+  an_optional_union_2: require('react').PropTypes.oneOfType([require('react').PropTypes.string, require('react').PropTypes.number]),
   a_number: require('react').PropTypes.number.isRequired,
   a_boolean: require('react').PropTypes.bool.isRequired,
   a_generic_object: require('react').PropTypes.object.isRequired,


### PR DESCRIPTION
Flow allows you to have union types with `null` as an element. Currently the plugin does not handle this correctly but crashes with:
 `Invalid type supplied, this is a bug in babel-plugin-flow-react-proptypes, typeof is undefined with value undefined`.

This pull request should fix it. Please review @brigand 