### PR TITLE
Basic support for TupleTypeAnnotation

### DIFF
--- a/src/__test__/fixtures/tupletype.input.js
+++ b/src/__test__/fixtures/tupletype.input.js
@@ -1,0 +1,10 @@
+var React = require('react');
+
+type T = {
+  an_optional_string?: string,
+  tupletype: [string, Object]
+}
+
+export default function Foo(props: T) {
+    <div />
+}

--- a/src/__test__/fixtures/tupletype.output.js
+++ b/src/__test__/fixtures/tupletype.output.js
@@ -1,0 +1,16 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = Foo;
+var React = require('react');
+
+function Foo(props) {
+  React.createElement('div', null);
+}
+Foo.propTypes = {
+  an_optional_string: require('react').PropTypes.string,
+  tupletype: require('react').PropTypes.arrayOf(require('react').PropTypes.any).isRequired
+};
+

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -29,6 +29,7 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
   else if (node.type === 'StringTypeAnnotation') resultPropType = {type: 'string'};
   else if (node.type === 'BooleanTypeAnnotation') resultPropType = {type: 'bool'};
   else if (node.type === 'VoidTypeAnnotation') resultPropType = {type: 'void'};
+  else if (node.type === 'TupleTypeAnnotation') resultPropType = {type: 'arrayOf', of: {type: 'any'}};
   else if (node.type === 'NullableTypeAnnotation') {
     resultPropType = convertToPropTypes(node.typeAnnotation, importedTypes, internalTypes);
     resultPropType.optional = true;


### PR DESCRIPTION
Currently any code using flow tuple types like `[string, Object]` will crash the plugin.

As PropTypes does not support tuples this just introduces basic handling with `PropTypes.arrayOf(PropTypes.any).isRequired`