### PR TITLE
Reuse typeannotation logic to fix bug with inline props (solves #35)

### DIFF
--- a/src/__test__/fixtures/class-inline-props.input.js
+++ b/src/__test__/fixtures/class-inline-props.input.js
@@ -1,0 +1,14 @@
+// @flow
+var React = require('react');
+import type { ExternalType } from '../types';
+
+export default class Foo extends React.Component {
+  props: {
+    a_number: number,
+    external: ExternalType,
+  }
+
+  render () {
+    return <div />
+  }
+}

--- a/src/__test__/fixtures/class-inline-props.output.js
+++ b/src/__test__/fixtures/class-inline-props.output.js
@@ -1,0 +1,43 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var babelPluginFlowReactPropTypes_proptype_ExternalType = require('../types').babelPluginFlowReactPropTypes_proptype_ExternalType || require('react').PropTypes.any;
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement('div', null);
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  a_number: require('react').PropTypes.number.isRequired,
+  external: babelPluginFlowReactPropTypes_proptype_ExternalType
+};
+exports.default = Foo;
+


### PR DESCRIPTION
This solves #35 where type annotation given directly in props for a subclass crashes the plugin.

It reuses the same logic from functional components, so using external types now also works.