### PR TITLE
Handle functional components export + declaration

### DIFF
--- a/src/__test__/fixtures/stateless-exports.input.js
+++ b/src/__test__/fixtures/stateless-exports.input.js
@@ -1,0 +1,10 @@
+// @flow
+import React from "react";
+
+export const C1 = ({ m } : { m : string }) => {
+  return <div />;
+};
+
+export const C2 = function({ m } : { m : string }) {
+  return <div />;
+};

--- a/src/__test__/fixtures/stateless-exports.output.js
+++ b/src/__test__/fixtures/stateless-exports.output.js
@@ -1,0 +1,30 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.C2 = exports.C1 = undefined;
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var C1 = exports.C1 = function C1(_ref) {
+  var m = _ref.m;
+
+  return _react2.default.createElement("div", null);
+};
+C1.propTypes = {
+  m: require("react").PropTypes.string.isRequired
+};
+var C2 = exports.C2 = function C2(_ref2) {
+  var m = _ref2.m;
+
+  return _react2.default.createElement("div", null);
+};
+C2.propTypes = {
+  m: require("react").PropTypes.string.isRequired
+};
+

--- a/src/index.js
+++ b/src/index.js
@@ -85,13 +85,11 @@ export default function flowReactPropTypes(babel) {
     let name;
     let targetPath;
 
-    if (path.type === 'ArrowFunctionExpression') {
+
+    if (path.type === 'ArrowFunctionExpression' || path.type === 'FunctionExpression') {
       name = path.parent.id.name;
-      targetPath = path.parentPath.parentPath;
-    }
-    else if (path.type === 'FunctionExpression') {
-      name = path.parent.id.name;
-      targetPath = path.parentPath.parentPath;
+      const basePath = path.parentPath.parentPath;
+      targetPath = t.isExportDeclaration(basePath.parent) ? basePath.parentPath : basePath;
     }
     else {
       name = path.node.id.name;


### PR DESCRIPTION
When functional components are declared and exported in the same statement we currently crash. This should fix it.

```javascript
export const C = ({ message } : {
  message : string
}) => {
    return <div />;
};
```

Fixes https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/35

Please review @brigand 