### PR TITLE
Arrowfunctions without body as BlockStatement

### DIFF
--- a/src/__test__/fixtures/stateless-arrow-body-without-jsx.input.js
+++ b/src/__test__/fixtures/stateless-arrow-body-without-jsx.input.js
@@ -1,0 +1,19 @@
+var React = require('react');
+
+const arrowFunctionWithBody = () => window.console;
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+const Foo = (props: FooT) => (
+  React.createElement(
+    'div',
+    null,
+    props.x
+  )
+);
+
+export default Foo;

--- a/src/__test__/fixtures/stateless-arrow-body-without-jsx.output.js
+++ b/src/__test__/fixtures/stateless-arrow-body-without-jsx.output.js
@@ -1,0 +1,20 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var React = require('react');
+
+var arrowFunctionWithBody = function arrowFunctionWithBody() {
+  return window.console;
+};
+
+var Foo = function Foo(props) {
+  return React.createElement('div', null, props.x);
+};
+
+Foo.propTypes = {
+  x: require('react').PropTypes.oneOf(['option1', 'option2'])
+};
+exports.default = Foo;
+

--- a/src/__test__/fixtures/stateless-arrow-body.input.js
+++ b/src/__test__/fixtures/stateless-arrow-body.input.js
@@ -1,0 +1,17 @@
+var React = require('react');
+
+const arrowFunctionWithBody = () => window.console;
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+const Foo = (props: FooT) => (
+  <div>{props.x}</div>
+);
+
+const Bar = (props: FooT) => <div>{props.x}</div>;
+
+export default Foo;

--- a/src/__test__/fixtures/stateless-arrow-body.output.js
+++ b/src/__test__/fixtures/stateless-arrow-body.output.js
@@ -1,0 +1,35 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var React = require('react');
+
+var arrowFunctionWithBody = function arrowFunctionWithBody() {
+  return window.console;
+};
+
+var Foo = function Foo(props) {
+  return React.createElement(
+    'div',
+    null,
+    props.x
+  );
+};
+
+Foo.propTypes = {
+  x: require('react').PropTypes.oneOf(['option1', 'option2'])
+};
+var Bar = function Bar(props) {
+  return React.createElement(
+    'div',
+    null,
+    props.x
+  );
+};
+
+Bar.propTypes = {
+  x: require('react').PropTypes.oneOf(['option1', 'option2'])
+};
+exports.default = Foo;
+

--- a/src/index.js
+++ b/src/index.js
@@ -53,29 +53,39 @@ export default function flowReactPropTypes(babel) {
   const t = babel.types;
 
   const isFunctionalReactComponent = path => {
-    const bodyParts = path.node.body.body;
-    if (!bodyParts) {
-      return false;
-    }
-
     if ((path.type === 'ArrowFunctionExpression' || path.type === 'FunctionExpression') && !path.parent.id) {
       // Could be functions inside a React component
       return false;
     }
-
-    for (let i = 0; i < bodyParts.length; i++) {
-      const b = bodyParts[i];
-      if (t.isExpressionStatement(b)) {
-        if (t.isJSXElement(b.expression)) {
-          return true;
-        }
-        const callee = b.expression.callee;
-        if (callee && callee.object && ['createElement', 'React'].indexOf(callee.object.name) >= 0) {
-          return true;
-        }
-      }
-      if (t.isReturnStatement(b) && t.isJSXElement(b.argument)) {
+    if (t.isJSXElement(path.node.body)) {
+      return true;
+    }
+    if (t.isCallExpression(path.node.body)) {
+      const callee = path.node.body.callee;
+      if (callee && callee.object && ['createElement', 'React'].indexOf(callee.object.name) >= 0) {
         return true;
+      }
+    }
+    if (t.isBlockStatement(path.node.body)) {
+      const bodyParts = path.node.body.body;
+      if (!bodyParts) {
+        return false;
+      }
+
+      for (let i = 0; i < bodyParts.length; i++) {
+        const b = bodyParts[i];
+        if (t.isExpressionStatement(b)) {
+          if (t.isJSXElement(b.expression)) {
+            return true;
+          }
+          const callee = b.expression.callee;
+          if (callee && callee.object && ['createElement', 'React'].indexOf(callee.object.name) >= 0) {
+            return true;
+          }
+        }
+        if (t.isReturnStatement(b) && t.isJSXElement(b.argument)) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
At my company we have many stateless functional components without
BlockStatement as body. Like this:

```js
type Props = { x: string }
const Foo = (props: Props) => <div>{props.x}</div>;
export default Foo;
```

This patch checks the body for JSX and React.createElement, if the body
is a block statement it behaves as before.