### PR TITLE
Fixed crash when props are annotated as Object

### DIFF
--- a/src/__test__/fixtures/object-props.input.js
+++ b/src/__test__/fixtures/object-props.input.js
@@ -1,0 +1,1 @@
+const Component = (props: Object) => <div />;

--- a/src/__test__/fixtures/object-props.output.js
+++ b/src/__test__/fixtures/object-props.output.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var Component = function Component(props) {
+  return React.createElement("div", null);
+};
+

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -4,8 +4,7 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
   $debug('convertToPropTypes', node);
   let resultPropType;
   
-  if (!node) resultPropType = {};
-  else if (node.type === 'ObjectTypeAnnotation') {
+  if (node.type === 'ObjectTypeAnnotation') {
     const ret = node.properties.map((subnode) => {
       const key = subnode.key.name;
       let value = subnode.value;

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -3,8 +3,9 @@ import {$debug, PLUGIN_NAME} from './util';
 export default function convertToPropTypes(node, importedTypes, internalTypes) {
   $debug('convertToPropTypes', node);
   let resultPropType;
-
-  if (node.type === 'ObjectTypeAnnotation') {
+  
+  if (!node) resultPropType = {};
+  else if (node.type === 'ObjectTypeAnnotation') {
     const ret = node.properties.map((subnode) => {
       const key = subnode.key.name;
       let value = subnode.value;

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const getPropsForTypeAnnotation = typeAnnotation => {
   if (typeAnnotationReference) {
     props = internalTypes[typeAnnotationReference] || importedTypes[typeAnnotationReference];
     if (!props) {
-      throw new Error(`Did not find type annotation for reference ${typeAnnotationReference}`);
+      $debug(`Did not find type annotation for reference ${typeAnnotationReference}`);
     }
   }
   else if (typeAnnotation.properties) {


### PR DESCRIPTION
Right now, this example:
```
const MyComponent = (props: Object) => <div />;
```

Results in:
```
Error: index.js: Did not find type annotation for reference Object
    at getPropsForTypeAnnotation (C:\Projects\test\node_modules\babel-plugin-flow-react-proptypes\lib\index.js:38:13)
    at getFunctionalComponentTypeProps (C:\Projects\test\node_modules\babel-plugin-flow-react-proptypes\lib\index.js:59:10)
    at functionVisitor (C:\Projects\test\node_modules\babel-plugin-flow-react-proptypes\lib\index.js:138:17)
    at PluginPass.ArrowFunctionExpression (C:\Projects\test\node_modules\babel-plugin-flow-react-proptypes\lib\index.js:198:16)
    at newFn (C:\Projects\test\node_modules\babel-traverse\lib\visitors.js:276:21)
    at NodePath._call (C:\Projects\test\node_modules\babel-traverse\lib\path\context.js:76:18)
    at NodePath.call (C:\Projects\test\node_modules\babel-traverse\lib\path\context.js:48:17)
    at NodePath.visit (C:\Projects\test\node_modules\babel-traverse\lib\path\context.js:105:12)
    at TraversalContext.visitQueue (C:\Projects\test\node_modules\babel-traverse\lib\context.js:150:16)
    at TraversalContext.visitSingle (C:\Projects\test\node_modules\babel-traverse\lib\context.js:108:19)
```

If the props are Object, then we don't need propTypes, just skip generating them.