### PR TITLE
Use package.json files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/brigand/babel-plugin-flow-react-proptypes/issues"
   },
   "homepage": "https://github.com/brigand/babel-plugin-flow-react-proptypes#readme",
+  "files": [
+    "lib/*.js"
+  ],
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",


### PR DESCRIPTION
I also ran into #50, where flow was warning for files inside this module. I noticed that source code and tests were being included in the published npm package, so I took a stab at fixing (or working around, depending on whether that's actually a bug in flow itself) it by including only the compiled source in the published package. Without the uncompiled source and tests, the npm package is smaller, and flow has nothing to complain about. I should note that this approach will only work as long as the source and tests don't need to be in the bundle. Typically they aren't included, but perhaps there's a use case I'm not seeing that would require them.

```sh
$ npm run build

> babel-plugin-flow-react-proptypes@0.17.2 build ~/code/brigand/babel-plugin-flow-react-proptypes
> babel src/ --out-dir lib/ --ignore src/__tests__ --presets es2015,stage-1,react

src/convertToPropTypes.js -> lib/convertToPropTypes.js
src/index.js -> lib/index.js
src/makePropTypesAst.js -> lib/makePropTypesAst.js
src/util.js -> lib/util.js
$ npm pack
babel-plugin-flow-react-proptypes-0.17.2.tgz
$ tar -tvf babel-plugin-flow-react-proptypes-0.17.2.tgz
package/package.json
package/README.md
package/LICENSE
package/lib/convertToPropTypes.js
package/lib/index.js
package/lib/makePropTypesAst.js
package/lib/util.js
```

Fixes #50.