### PR TITLE
Properly handle exporting named types

### DIFF
--- a/src/__tests__/__snapshots__/export-object-test.js.snap
+++ b/src/__tests__/__snapshots__/export-object-test.js.snap
@@ -1,9 +1,11 @@
 exports[`test export-object 1`] = `
 "\'use strict\';
 
-Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_Foo\', require(\'react\').PropTypes.shape({
-  a_string: require(\'react\').PropTypes.string.isRequired
-}));
+Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_Foo\', {
+  value: require(\'react\').PropTypes.shape({
+    a_string: require(\'react\').PropTypes.string.isRequired
+  })
+});
 
 
 console.log(\'test\');"

--- a/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
+++ b/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
@@ -11,11 +11,13 @@ var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_T\', require(\'react\').PropTypes.shape({
-  f: require(\'react\').PropTypes.func.isRequired,
-  i: require(\'react\').PropTypes.number.isRequired,
-  x: require(\'react\').PropTypes.oneOf([\'foo\', \'baz\']).isRequired
-}));
+Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+  value: require(\'react\').PropTypes.shape({
+    f: require(\'react\').PropTypes.func.isRequired,
+    i: require(\'react\').PropTypes.number.isRequired,
+    x: require(\'react\').PropTypes.oneOf([\'foo\', \'baz\']).isRequired
+  })
+});
 
 
 var C = function C(_ref) {

--- a/src/__tests__/__snapshots__/import-and-loops-test.js.snap
+++ b/src/__tests__/__snapshots__/import-and-loops-test.js.snap
@@ -13,10 +13,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var babelPluginFlowReactPropTypes_proptype_ExternalType = require(\'../types\').babelPluginFlowReactPropTypes_proptype_ExternalType || require(\'react\').PropTypes.any;
 
-Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_T\', require(\'react\').PropTypes.shape({
-    flag: require(\'react\').PropTypes.bool.isRequired,
-    list: require(\'react\').PropTypes.arrayOf(babelPluginFlowReactPropTypes_proptype_ExternalType).isRequired
-}));
+Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+    value: require(\'react\').PropTypes.shape({
+        flag: require(\'react\').PropTypes.bool.isRequired,
+        list: require(\'react\').PropTypes.arrayOf(babelPluginFlowReactPropTypes_proptype_ExternalType).isRequired
+    })
+});
 
 
 var C = function C(_ref) {

--- a/src/__tests__/__snapshots__/typeof-test.js.snap
+++ b/src/__tests__/__snapshots__/typeof-test.js.snap
@@ -5,8 +5,10 @@ var ActionTypes = {
   JUMP_TO: \'react-native/NavigationExperimental/tabs-jumpTo\'
 };
 
-Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_JumpToAction\', require(\'react\').PropTypes.shape({
-  type: require(\'react\').PropTypes.any.isRequired,
-  index: require(\'react\').PropTypes.number.isRequired
-}));"
+Object.defineProperty(module.exports, \'babelPluginFlowReactPropTypes_proptype_JumpToAction\', {
+  value: require(\'react\').PropTypes.shape({
+    type: require(\'react\').PropTypes.any.isRequired,
+    index: require(\'react\').PropTypes.number.isRequired
+  })
+});"
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ module.exports = function flowReactPropTypes(babel) {
           [
             t.memberExpression(t.identifier('module'), t.identifier('exports')),
             t.stringLiteral(getExportNameForType(name)),
-            propTypesAst,
+            t.objectExpression([t.objectProperty(t.identifier('value'), propTypesAst)]),
           ]
         ));
         path.insertAfter(exportAst);


### PR DESCRIPTION
Object.defineProperty takes a descriptor not a value. Value was always undefined and defaulting to any type when the import was processed.