### PR TITLE
Fix hoc

### DIFF
--- a/src/__tests__/__snapshots__/hoc.js.snap
+++ b/src/__tests__/__snapshots__/hoc.js.snap
@@ -2,7 +2,7 @@ exports[`test import-object 1`] = `
 "\"use strict\";
 
 Object.defineProperty(exports, \"__esModule\", {
-	value: true
+  value: true
 });
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
@@ -12,22 +12,22 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 exports.default = function () {
-	var C = function (_React$Component) {
-		_inherits(C, _React$Component);
+  var C = function (_React$Component) {
+    _inherits(C, _React$Component);
 
-		function C() {
-			_classCallCheck(this, C);
+    function C() {
+      _classCallCheck(this, C);
 
-			return _possibleConstructorReturn(this, (C.__proto__ || Object.getPrototypeOf(C)).apply(this, arguments));
-		}
+      return _possibleConstructorReturn(this, (C.__proto__ || Object.getPrototypeOf(C)).apply(this, arguments));
+    }
 
-		return C;
-	}(React.Component);
+    return C;
+  }(React.Component);
 
-	C.propTypes = {
-		a_prop: require(\"prop-types\").bool.isRequired
-	};
+  C.propTypes = {
+    a_prop: require(\"prop-types\").bool.isRequired
+  };
 
-	return C;
+  return C;
 };"
 `;

--- a/src/__tests__/__snapshots__/hoc.js.snap
+++ b/src/__tests__/__snapshots__/hoc.js.snap
@@ -1,0 +1,33 @@
+exports[`test import-object 1`] = `
+"\"use strict\";
+
+Object.defineProperty(exports, \"__esModule\", {
+	value: true
+});
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+exports.default = function () {
+	var C = function (_React$Component) {
+		_inherits(C, _React$Component);
+
+		function C() {
+			_classCallCheck(this, C);
+
+			return _possibleConstructorReturn(this, (C.__proto__ || Object.getPrototypeOf(C)).apply(this, arguments));
+		}
+
+		return C;
+	}(React.Component);
+
+	C.propTypes = {
+		a_prop: require(\"prop-types\").bool.isRequired
+	};
+
+	return C;
+};"
+`;

--- a/src/__tests__/hoc.js
+++ b/src/__tests__/hoc.js
@@ -5,10 +5,10 @@ type FooProps = {
 };
 
 export default () => {
-	class C extends React.Component {
+  class C extends React.Component {
     props: FooProps;
-	}
-	return C;
+  }
+  return C;
 };
 `;
 
@@ -18,6 +18,6 @@ it('import-object', () => {
     presets: ['es2015', 'stage-1', 'react'],
     plugins: ['syntax-flow', require('../')],
   }).code;
-	console.log(res);
+  console.log(res);
   expect(res).toMatchSnapshot();
 });

--- a/src/__tests__/hoc.js
+++ b/src/__tests__/hoc.js
@@ -1,0 +1,23 @@
+var babel = require('babel-core');
+var content = `
+type FooProps = {
+  a_prop: boolean,
+};
+
+export default () => {
+	class C extends React.Component {
+    props: FooProps;
+	}
+	return C;
+};
+`;
+
+it('import-object', () => {
+  var res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+	console.log(res);
+  expect(res).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ module.exports = function flowReactPropTypes(babel) {
     }
     else {
       name = path.node.id.name;
-      targetPath = path.parent.type === 'Program' ? path : path.parentPath;
+      targetPath = ['Program', 'BlockStatement'].indexOf(path.parent.type) >= 0 ? path : path.parentPath;
     }
 
     if (!props) {


### PR DESCRIPTION
Fixes #73 - looks like `Babel` is appending extra block `{ }` when we are calling `insertAfter` on `BlockStatement`.