### PR TITLE
Suppress transform of any file in node_modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,12 @@ module.exports = function flowReactPropTypes(babel) {
             suppress = true;
           }
         }
+        if (this.file && this.file.opt && this.file.opt.filename) {
+          if (this.file.opts.filename.indexOf("node_modules") >= 0) {
+            // Suppress any file that lives in node_modules
+            suppress = true;
+          }
+        }
       },
       TypeAlias(path) {
         if (suppress) return;


### PR DESCRIPTION
Required to work with React Native as the packager applies the application's babelrc to node_modules (and breaks in many and fun ways on React Native's sources when using this plugin).

Fixes #62 #53