### PR TITLE
Add a babel option ignoreNodeModules to control transform on node modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ module.exports = function flowReactPropTypes(babel) {
 
   return {
     visitor: {
-      Program(path) {
+      Program(path, {opts}) {
         internalTypes = {};
         importedTypes = {};
         suppress = false;
@@ -137,8 +137,9 @@ module.exports = function flowReactPropTypes(babel) {
         }
         if (this.file && this.file.opts && this.file.opts.filename) {
           if (this.file.opts.filename.indexOf('node_modules') >= 0) {
-            // Suppress any file that lives in node_modules
-            suppress = true;
+            // Suppress any file that lives in node_modules IF the
+            // ignoreNodeModules setting is true
+            suppress = opts.ignoreNodeModules;
           }
         }
       },


### PR DESCRIPTION
@brigand @chrisy-lili This adds an option to disable transforming node modules rather than making this a hard decision.

The default is to transform node modules.