### PR TITLE
Enable code coverage & coveralls badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
 script:
   - npm run lint
   - npm run test
+  - npm run coveralls
   - npm run build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 A babel plugin to generate React PropTypes definitions from Flow type declarations.
 
 [![build status](https://img.shields.io/travis/brigand/babel-plugin-flow-react-proptypes/master.svg?style=flat-square)](https://travis-ci.org/brigand/babel-plugin-flow-react-proptypes)
+[![Coverage Status](https://coveralls.io/repos/github/brigand/babel-plugin-flow-react-proptypes/badge.svg?branch=master)](https://coveralls.io/github/brigand/babel-plugin-flow-react-proptypes?branch=master)
 [![npm version](https://img.shields.io/npm/v/babel-plugin-flow-react-proptypes.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-flow-react-proptypes)
 [![npm downloads](https://img.shields.io/npm/dm/babel-plugin-flow-react-proptypes.svg?style=flat-square)](https://www.npmjs.com/package/babel-plugin-flow-react-proptypes)
 [![Dependency Status](https://img.shields.io/david/brigand/babel-plugin-flow-react-proptypes.svg?style=flat-square)](https://david-dm.org/brigand/babel-plugin-flow-react-proptypes)

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint src test",
-    "test": "npm run build && jest",
+    "test": "npm run build && jest --coverage",
     "build": "babel src/ --out-dir lib/ --ignore src/__tests__ --presets es2015,stage-1,react",
-    "predeploy": "npm run build && npm run lint"
+    "predeploy": "npm run build && npm run lint",
+    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
+    "coveralls": "^2.13.1",
     "eslint": "^3.8.1",
     "eslint-plugin-react": "^6.4.1",
     "jest": "^17.0.3",


### PR DESCRIPTION
This PR adds a coverage badge to README.md via the coveralls.io service.

I can't properly test the travis integration. My impression is that it should work out of the box once the repo owner creates an account on coveralls.io and enables the correct repository.

The npm command itself works fine, I tried it: https://coveralls.io/github/mhaas/babel-plugin-flow-react-proptypes