### PR TITLE
Fix issue #66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+  - Fix error on attempted propTypes generation for non-component function (#66)
+
 ## 3.1.2
   -  Fix bug with functions defaulting to react components (#97)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  -  Fix bug with functions defaulting to react components (#97)
+
 ## 3.1.0
 
   - Add support for top-level propTypes assignment of imported types (#88)

--- a/src/__tests__/__snapshots__/test-issue-66.js.snap
+++ b/src/__tests__/__snapshots__/test-issue-66.js.snap
@@ -1,0 +1,14 @@
+exports[`test issue 66 1`] = `
+"\"use strict\";
+
+Object.defineProperty(exports, \"__esModule\", {
+  value: true
+});
+
+exports.default = function (url, options) {
+  var Html = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : DefaultHtml;
+
+
+  return React.createElement(\"div\", null);
+};"
+`;

--- a/src/__tests__/test-issue-66.js
+++ b/src/__tests__/test-issue-66.js
@@ -1,0 +1,25 @@
+const babel = require('babel-core');
+const content = `
+
+// @flow
+
+export default function(
+  url: string,
+  options: PhenomicStaticConfig,
+  Html: Function = DefaultHtml
+): Promise<string> {
+
+  return <div/>;
+}
+
+
+`;
+
+it('issue 66', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,9 @@ const getPropsForTypeAnnotation = typeAnnotation => {
       || typeAnnotation.type === 'AnyTypeAnnotation') {
     props = convertNodeToPropTypes(typeAnnotation);
   }
+  else if (typeAnnotation.properties != null || typeAnnotation.type != null) {
+    $debug('typeAnnotation not of expected type, not generating propTypes: ', typeAnnotation);
+  }
   else {
     throw new Error(`Expected prop types, but found none. This is a bug in ${PLUGIN_NAME}`);
   }


### PR DESCRIPTION
Any function containing a react component is considered a functional
React component by isFunctionalReactComponent().

This leads to false positives for functions which just use or generate
instances of React components. These factory functions do not
follow the general contract of react components. In particular, the
first argument to the function may not be props.

It is hard to detect these cases in isFunctionalReactComponent. Instead,
we relax the sanity check in getPropsForTypeAnnotation: if a typeAnnotation
exists but does not have the type we expect, we do not fail hard.
We just don't generate proptypes.

Not sure if this is the best way to go about this, but it's a start.