### PR TITLE
Babel 7 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 npm-debug.log
 .DS_Store
 src/__tests__/lib/test-types.js.transpiled
+yarn.lock
+coverage

--- a/package.json
+++ b/package.json
@@ -34,25 +34,25 @@
     "lib/*.js"
   ],
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-eslint": "^7.1.0",
-    "babel-jest": "^17.0.2",
-    "babel-plugin-syntax-flow": "^6.18.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-1": "^6.16.0",
+    "babel-cli": "^7.0.0-alpha.12",
+    "babel-eslint": "^7.2.3",
+    "babel-jest": "^20.0.3",
+    "babel-plugin-syntax-flow": "^7.0.0-alpha.12",
+    "babel-preset-es2015": "^7.0.0-alpha.12",
+    "babel-preset-react": "^7.0.0-alpha.12",
+    "babel-preset-stage-1": "^7.0.0-alpha.12",
     "coveralls": "^2.13.1",
-    "eslint": "^3.8.1",
-    "eslint-plugin-react": "^6.4.1",
-    "jest": "^17.0.3",
+    "eslint": "^3.19.0",
+    "eslint-plugin-react": "^7.0.1",
+    "jest": "^20.0.4",
     "react": "^15.5.4",
     "react-test-renderer": "^15.5.4"
   },
   "dependencies": {
-    "babel-template": "^6.16.0",
-    "babel-traverse": "^6.18.0",
-    "babel-types": "^6.18.0",
-    "babel-core": "^6.18.0"
+    "babel-template": "7.0.0-alpha.12",
+    "babel-traverse": "^7.0.0-alpha.12",
+    "babel-types": "^7.0.0-alpha.12",
+    "babel-core": "^7.0.0-alpha.12"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^7.0.0-alpha.12",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "babel/babel-eslint",
     "babel-jest": "^20.0.3",
     "babel-plugin-syntax-flow": "^7.0.0-alpha.12",
     "babel-preset-es2015": "^7.0.0-alpha.12",
@@ -49,15 +49,63 @@
     "react-test-renderer": "^15.5.4"
   },
   "dependencies": {
+    "babel-core": "^7.0.0-alpha.12",
     "babel-template": "7.0.0-alpha.12",
     "babel-traverse": "^7.0.0-alpha.12",
-    "babel-types": "^7.0.0-alpha.12",
-    "babel-core": "^7.0.0-alpha.12"
+    "babel-types": "^7.0.0-alpha.12"
   },
   "jest": {
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/lib/"
     ]
+  },
+  "resolutions": {
+    "babel-template": "7.0.0-alpha.12",
+    "babel-traverse": "7.0.0-alpha.12",
+    "babel-types": "7.0.0-alpha.12",
+    "babel-core": "7.0.0-alpha.12",
+    "babylon": "7.0.0-beta.13",
+    "babel-code-frame": "7.0.0-alpha.12",
+    "babel-helper-function-name": "7.0.0-alpha.12",
+    "babel-messages": "7.0.0-alpha.3",
+    "ansi-styles": "3.0.0",
+    "supports-color": "3.2.3",
+    "babel-helper-get-function-arity": "7.0.0-alpha.12",
+    "babel-generator": "7.0.0-alpha.12",
+    "babel-helpers": "7.0.0-alpha.12",
+    "resolve": "1.3.3",
+    "source-map": "0.5.6",
+    "jsesc": "1.3.0",
+    "babel-register": "7.0.0-alpha.12",
+    "core-js": "2.4.1",
+    "home-or-tmp": "3.0.0",
+    "find-up": "2.1.0",
+    "path-exists": "3.0.0",
+    "minimist": "1.2.0",
+    "user-home": "2.0.0",
+    "request": "2.81.0",
+    "string-width": "2.0.0",
+    "is-fullwidth-code-point": "2.0.0",
+    "caseless": "0.12.0",
+    "har-validator": "4.2.1",
+    "qs": "6.4.0",
+    "tunnel-agent": "0.6.0",
+    "assert-plus": "1.0.0",
+    "strip-bom": "3.0.0",
+    "babel-helper-regex": "7.0.0-alpha.12",
+    "js-yaml": "3.8.4",
+    "esprima": "3.1.3",
+    "estraverse": "4.2.0",
+    "acorn": "5.0.3",
+    "wordwrap": "1.0.0",
+    "callsites": "2.0.0",
+    "yargs": "7.1.0",
+    "async": "2.4.1",
+    "camelcase": "3.0.0",
+    "cliui": "3.2.0",
+    "webidl-conversions": "4.0.1",
+    "fb-watchman": "2.0.0",
+    "bser": "2.0.0"
   }
 }

--- a/src/__tests__/__snapshots__/array-shorthand-test.js.snap
+++ b/src/__tests__/__snapshots__/array-shorthand-test.js.snap
@@ -1,17 +1,19 @@
-exports[`test array-shorthand 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`array-shorthand 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -23,9 +25,9 @@ var C = function (_React$Component) {
   }
 
   _createClass(C, [{
-    key: \"render\",
+    key: \\"render\\",
     value: function render() {
-      return React.createElement(\"div\", null);
+      return React.createElement(\\"div\\", null);
     }
   }]);
 
@@ -33,7 +35,7 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  as: require(\"prop-types\").arrayOf(require(\"prop-types\").string).isRequired
+  as: require(\\"prop-types\\").arrayOf(require(\\"prop-types\\").string).isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/basic-test.js.snap
+++ b/src/__tests__/__snapshots__/basic-test.js.snap
@@ -1,25 +1,27 @@
-exports[`test basic 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`basic 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_Qux\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Qux', {
   value: {
-    baz: require(\'prop-types\').oneOf([\'literal\']).isRequired
+    baz: require('prop-types').oneOf(['literal']).isRequired
   }
 });
 
-var babelPluginFlowReactPropTypes_proptype_SomeExternalType = require(\'./types\').babelPluginFlowReactPropTypes_proptype_SomeExternalType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_SomeExternalType = require('./types').babelPluginFlowReactPropTypes_proptype_SomeExternalType || require('prop-types').any;
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);
@@ -34,37 +36,37 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  an_optional_string: require(\'prop-types\').string,
-  a_number: require(\'prop-types\').number.isRequired,
-  a_boolean: require(\'prop-types\').bool.isRequired,
-  a_generic_object: require(\'prop-types\').object.isRequired,
-  array_of_strings: require(\'prop-types\').arrayOf(require(\'prop-types\').string).isRequired,
-  instance_of_Bar: typeof Bar === \'function\' ? require(\'prop-types\').instanceOf(Bar).isRequired : require(\'prop-types\').any.isRequired,
-  anything: require(\'prop-types\').any.isRequired,
-  mixed: require(\'prop-types\').any.isRequired,
-  one_of: require(\'prop-types\').oneOf([\'QUACK\', \'BARK\', 5]).isRequired,
-  one_of_type: require(\'prop-types\').oneOfType([require(\'prop-types\').number, require(\'prop-types\').string]).isRequired,
-  nested_object_level_1: require(\'prop-types\').shape({
-    string_property_1: require(\'prop-types\').string.isRequired,
-    nested_object_level_2: require(\'prop-types\').shape({
-      nested_object_level_3: require(\'prop-types\').shape({
-        string_property_3: require(\'prop-types\').string.isRequired
+  an_optional_string: require('prop-types').string,
+  a_number: require('prop-types').number.isRequired,
+  a_boolean: require('prop-types').bool.isRequired,
+  a_generic_object: require('prop-types').object.isRequired,
+  array_of_strings: require('prop-types').arrayOf(require('prop-types').string).isRequired,
+  instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
+  anything: require('prop-types').any.isRequired,
+  mixed: require('prop-types').any.isRequired,
+  one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,
+  one_of_type: require('prop-types').oneOfType([require('prop-types').number, require('prop-types').string]).isRequired,
+  nested_object_level_1: require('prop-types').shape({
+    string_property_1: require('prop-types').string.isRequired,
+    nested_object_level_2: require('prop-types').shape({
+      nested_object_level_3: require('prop-types').shape({
+        string_property_3: require('prop-types').string.isRequired
       }).isRequired,
-      string_property_2: require(\'prop-types\').string.isRequired
+      string_property_2: require('prop-types').string.isRequired
     }).isRequired
   }).isRequired,
   should_error_if_provided: function should_error_if_provided(props, propName, componentName) {
-    if (props[propName] != null) return new Error(\'Invalid prop \`\' + propName + \'\` of value \`\' + value + \'\` passed to \`\' + componentName + \'\`. Expected undefined or null.\');
+    if (props[propName] != null) return new Error('Invalid prop \`' + propName + '\` of value \`' + value + '\` passed to \`' + componentName + '\`. Expected undefined or null.');
   },
-  intersection: require(\'prop-types\').shape({
-    foo: require(\'prop-types\').string.isRequired,
-    bar: require(\'prop-types\').number.isRequired,
-    baz: require(\'prop-types\').oneOf([\'literal\']).isRequired
+  intersection: require('prop-types').shape({
+    foo: require('prop-types').string.isRequired,
+    bar: require('prop-types').number.isRequired,
+    baz: require('prop-types').oneOf(['literal']).isRequired
   }).isRequired,
-  some_external_type: typeof babelPluginFlowReactPropTypes_proptype_SomeExternalType === \'function\' ? babelPluginFlowReactPropTypes_proptype_SomeExternalType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_SomeExternalType).isRequired,
-  some_external_type_intersection: require(\'prop-types\').shape(Object.assign({}, {
-    foo: require(\'prop-types\').string.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_SomeExternalType === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_SomeExternalType)).isRequired
+  some_external_type: typeof babelPluginFlowReactPropTypes_proptype_SomeExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_SomeExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_SomeExternalType).isRequired,
+  some_external_type_intersection: require('prop-types').shape(Object.assign({}, {
+    foo: require('prop-types').string.isRequired
+  }, babelPluginFlowReactPropTypes_proptype_SomeExternalType === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_SomeExternalType)).isRequired
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/children-test.js.snap
+++ b/src/__tests__/__snapshots__/children-test.js.snap
@@ -1,16 +1,18 @@
-exports[`test children 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var React = require(\'react\');
+exports[`children 1`] = `
+"'use strict';
+
+var React = require('react');
 
 function Foo(props) {
   React.createElement(
-    \'div\',
+    'div',
     null,
     props.children
   );
 }
 Foo.propTypes = {
-  children: require(\'prop-types\').node.isRequired
+  children: require('prop-types').node.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/class-and-function-test.js.snap
+++ b/src/__tests__/__snapshots__/class-and-function-test.js.snap
@@ -1,23 +1,26 @@
-exports[`test class-and-function 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`class-and-function 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
     value: true
 });
+exports.default = undefined;
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var TaskGridHeader = function (_Component) {
     _inherits(TaskGridHeader, _Component);
@@ -29,7 +32,7 @@ var TaskGridHeader = function (_Component) {
     }
 
     _createClass(TaskGridHeader, [{
-        key: \'render\',
+        key: 'render',
         value: function render() {
             return null;
         }
@@ -39,12 +42,12 @@ var TaskGridHeader = function (_Component) {
 }(_react.Component);
 
 TaskGridHeader.propTypes = {
-    tasksSetSort: require(\'prop-types\').any.isRequired
+    tasksSetSort: require('prop-types').any.isRequired
 };
 exports.default = TaskGridHeader;
 
 
 var glyph = function glyph(param) {
-    return _react2.default.createElement(\'div\', null);
+    return _react2.default.createElement('div', null);
 };"
 `;

--- a/src/__tests__/__snapshots__/class-inline-props-test.js.snap
+++ b/src/__tests__/__snapshots__/class-inline-props-test.js.snap
@@ -1,21 +1,23 @@
-exports[`test class-inline-props 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`class-inline-props 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-var babelPluginFlowReactPropTypes_proptype_ExternalType = require(\'../types\').babelPluginFlowReactPropTypes_proptype_ExternalType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_ExternalType = require('../types').babelPluginFlowReactPropTypes_proptype_ExternalType || require('prop-types').any;
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);
@@ -27,9 +29,9 @@ var Foo = function (_React$Component) {
   }
 
   _createClass(Foo, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
-      return React.createElement(\'div\', null);
+      return React.createElement('div', null);
     }
   }]);
 
@@ -37,8 +39,8 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  a_number: require(\'prop-types\').number.isRequired,
-  external: typeof babelPluginFlowReactPropTypes_proptype_ExternalType === \'function\' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_ExternalType).isRequired
+  a_number: require('prop-types').number.isRequired,
+  external: typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType).isRequired
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/exact-syntax-test.js.snap
+++ b/src/__tests__/__snapshots__/exact-syntax-test.js.snap
@@ -1,13 +1,15 @@
-exports[`test exact-syntax 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+exports[`exact-syntax 1`] = `
+"\\"use strict\\";
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);
@@ -19,9 +21,9 @@ var Foo = function (_React$Component) {
   }
 
   _createClass(Foo, [{
-    key: \"render\",
+    key: \\"render\\",
     value: function render() {
-      return React.createElement(\"div\", null);
+      return React.createElement(\\"div\\", null);
     }
   }]);
 
@@ -29,9 +31,9 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  bar: require(\"prop-types\").shape({
-    a: require(\"prop-types\").string.isRequired,
-    b: require(\"prop-types\").number.isRequired,
+  bar: require(\\"prop-types\\").shape({
+    a: require(\\"prop-types\\").string.isRequired,
+    b: require(\\"prop-types\\").number.isRequired,
     __exact__: function __exact__(values, prop, displayName) {
       var props = {
         a: true,
@@ -46,7 +48,7 @@ Foo.propTypes = {
       }
 
       if (extra.length > 0) {
-        return new Error(\'Invalid additional prop(s) \' + JSON.stringify(extra));
+        return new Error('Invalid additional prop(s) ' + JSON.stringify(extra));
       }
     }
   }).isRequired

--- a/src/__tests__/__snapshots__/exact-test.js.snap
+++ b/src/__tests__/__snapshots__/exact-test.js.snap
@@ -1,13 +1,15 @@
-exports[`test exact 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+exports[`exact 1`] = `
+"\\"use strict\\";
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);
@@ -19,9 +21,9 @@ var Foo = function (_React$Component) {
   }
 
   _createClass(Foo, [{
-    key: \"render\",
+    key: \\"render\\",
     value: function render() {
-      return React.createElement(\"div\", null);
+      return React.createElement(\\"div\\", null);
     }
   }]);
 
@@ -29,9 +31,9 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  bar: require(\"prop-types\").shape({
-    a: require(\"prop-types\").string.isRequired,
-    b: require(\"prop-types\").number.isRequired,
+  bar: require(\\"prop-types\\").shape({
+    a: require(\\"prop-types\\").string.isRequired,
+    b: require(\\"prop-types\\").number.isRequired,
     __exact__: function __exact__(values, prop, displayName) {
       var props = {
         a: true,
@@ -46,7 +48,7 @@ Foo.propTypes = {
       }
 
       if (extra.length > 0) {
-        return new Error(\'Invalid additional prop(s) \' + JSON.stringify(extra));
+        return new Error('Invalid additional prop(s) ' + JSON.stringify(extra));
       }
     }
   }).isRequired

--- a/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -1,27 +1,29 @@
-exports[`test exported-intersection-exported-type-alias-unexported-object-literal 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`exported-intersection-exported-type-alias-unexported-object-literal 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: {
-    bar: require(\'prop-types\').string.isRequired
+    bar: require('prop-types').string.isRequired
   }
 });
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_U\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: {
-    bar: require(\'prop-types\').string.isRequired,
-    foo: require(\'prop-types\').string.isRequired
+    bar: require('prop-types').string.isRequired,
+    foo: require('prop-types').string.isRequired
   }
 });
 
@@ -38,8 +40,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  bar: require(\'prop-types\').string.isRequired,
-  foo: require(\'prop-types\').string.isRequired
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/export-intersection-type.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-type.js.snap
@@ -1,22 +1,24 @@
-exports[`test export-intersection-type 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`export-intersection-type 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_V\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_V', {
   value: {
-    foo: require(\'prop-types\').string.isRequired,
-    bar: require(\'prop-types\').string.isRequired
+    foo: require('prop-types').string.isRequired,
+    bar: require('prop-types').string.isRequired
   }
 });
 
@@ -33,8 +35,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  foo: require(\'prop-types\').string.isRequired,
-  bar: require(\'prop-types\').string.isRequired
+  foo: require('prop-types').string.isRequired,
+  bar: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/export-named-test.js.snap
+++ b/src/__tests__/__snapshots__/export-named-test.js.snap
@@ -1,24 +1,26 @@
-exports[`test export-named 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`export-named 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.ExportedVendorCard = undefined;
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var ExportedVendorCard = exports.ExportedVendorCard = function (_React$Component) {
   _inherits(ExportedVendorCard, _React$Component);
@@ -30,9 +32,9 @@ var ExportedVendorCard = exports.ExportedVendorCard = function (_React$Component
   }
 
   _createClass(ExportedVendorCard, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
-      return _react2.default.createElement(\'div\', null);
+      return _react2.default.createElement('div', null);
     }
   }]);
 
@@ -40,7 +42,7 @@ var ExportedVendorCard = exports.ExportedVendorCard = function (_React$Component
 }(_react2.default.Component);
 
 ExportedVendorCard.propTypes = {
-  test: require(\'prop-types\').string.isRequired
+  test: require('prop-types').string.isRequired
 };
 
 var LocalVendorCard = function (_React$Component2) {
@@ -53,9 +55,9 @@ var LocalVendorCard = function (_React$Component2) {
   }
 
   _createClass(LocalVendorCard, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
-      return _react2.default.createElement(\'div\', null);
+      return _react2.default.createElement('div', null);
     }
   }]);
 
@@ -63,6 +65,6 @@ var LocalVendorCard = function (_React$Component2) {
 }(_react2.default.Component);
 
 LocalVendorCard.propTypes = {
-  test: require(\'prop-types\').string.isRequired
+  test: require('prop-types').string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
+++ b/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
@@ -1,7 +1,9 @@
-exports[`test export-non-object-types 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_Answer\", {
-  value: require(\"prop-types\").oneOf([\"Yes\", \"No\"])
+exports[`export-non-object-types 1`] = `
+"\\"use strict\\";
+
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_Answer\\", {
+  value: require(\\"prop-types\\").oneOf([\\"Yes\\", \\"No\\"])
 });"
 `;

--- a/src/__tests__/__snapshots__/export-object-test.js.snap
+++ b/src/__tests__/__snapshots__/export-object-test.js.snap
@@ -1,12 +1,14 @@
-exports[`test export-object 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_Foo\', {
+exports[`export-object 1`] = `
+"'use strict';
+
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Foo', {
   value: {
-    a_string: require(\'prop-types\').string.isRequired
+    a_string: require('prop-types').string.isRequired
   }
 });
 
 
-console.log(\'test\');"
+console.log('test');"
 `;

--- a/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
+++ b/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
@@ -1,21 +1,23 @@
-exports[`test export-type-and-component 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`export-type-and-component 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: {
-    f: require(\'prop-types\').func.isRequired,
-    i: require(\'prop-types\').number.isRequired,
-    x: require(\'prop-types\').oneOf([\'foo\', \'baz\']).isRequired
+    f: require('prop-types').func.isRequired,
+    i: require('prop-types').number.isRequired,
+    x: require('prop-types').oneOf(['foo', 'baz']).isRequired
   }
 });
 
@@ -23,13 +25,13 @@ if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPlug
 var C = function C(_ref) {
   var f = _ref.f;
 
-  _react2.default.createElement(\'div\', null);
+  _react2.default.createElement('div', null);
 };
 
 C.propTypes = {
-  f: require(\'prop-types\').func.isRequired,
-  i: require(\'prop-types\').number.isRequired,
-  x: require(\'prop-types\').oneOf([\'foo\', \'baz\']).isRequired
+  f: require('prop-types').func.isRequired,
+  i: require('prop-types').number.isRequired,
+  x: require('prop-types').oneOf(['foo', 'baz']).isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/export-union-type.js.snap
+++ b/src/__tests__/__snapshots__/export-union-type.js.snap
@@ -1,7 +1,9 @@
-exports[`test export-union-type 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_A\", {
-  value: require(\"prop-types\").oneOf([\"option1\", \"option2\"])
+exports[`export-union-type 1`] = `
+"\\"use strict\\";
+
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_A\\", {
+  value: require(\\"prop-types\\").oneOf([\\"option1\\", \\"option2\\"])
 });"
 `;

--- a/src/__tests__/__snapshots__/function-types-test.js.snap
+++ b/src/__tests__/__snapshots__/function-types-test.js.snap
@@ -1,21 +1,23 @@
-exports[`test function-types 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`function-types 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var _react = require(\"react\");
+var _react = require(\\"react\\");
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MyComponent = function (_Component) {
   _inherits(MyComponent, _Component);
@@ -30,7 +32,7 @@ var MyComponent = function (_Component) {
 }(_react.Component);
 
 MyComponent.propTypes = {
-  onClick: require(\"prop-types\").func
+  onClick: require(\\"prop-types\\").func
 };
 exports.default = MyComponent;"
 `;

--- a/src/__tests__/__snapshots__/function-with-existential-type-test.js.snap
+++ b/src/__tests__/__snapshots__/function-with-existential-type-test.js.snap
@@ -1,8 +1,10 @@
-exports[`test function-with-type-annotation 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function-with-type-annotation 1`] = `
+"\\"use strict\\";
 
 var C = function C(props) {};
 C.propTypes = {
-  bar: require(\"prop-types\").any.isRequired
+  bar: require(\\"prop-types\\").any.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/function-with-generic-type-annotation-test.js.snap
+++ b/src/__tests__/__snapshots__/function-with-generic-type-annotation-test.js.snap
@@ -1,8 +1,10 @@
-exports[`test function-with-generic-type-annotation 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function-with-generic-type-annotation 1`] = `
+"\\"use strict\\";
 
 var C = function C(props) {};
 C.propTypes = {
-  name: require(\"prop-types\").string.isRequired
+  name: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/function-with-type-annotation-test.js.snap
+++ b/src/__tests__/__snapshots__/function-with-type-annotation-test.js.snap
@@ -1,8 +1,10 @@
-exports[`test function-with-type-annotation 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function-with-type-annotation 1`] = `
+"\\"use strict\\";
 
 var C = function C(props) {};
 C.propTypes = {
-  name: require(\"prop-types\").string.isRequired
+  name: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/hoc.js.snap
+++ b/src/__tests__/__snapshots__/hoc.js.snap
@@ -1,15 +1,17 @@
-exports[`test import-object 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`import-object 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 exports.default = function () {
   var C = function (_React$Component) {
@@ -25,7 +27,7 @@ exports.default = function () {
   }(React.Component);
 
   C.propTypes = {
-    a_prop: require(\"prop-types\").bool.isRequired
+    a_prop: require(\\"prop-types\\").bool.isRequired
   };
 
   return C;

--- a/src/__tests__/__snapshots__/ignoreNodeModules-test.js.snap
+++ b/src/__tests__/__snapshots__/ignoreNodeModules-test.js.snap
@@ -1,13 +1,15 @@
-exports[`test pure-component 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+exports[`pure-component 1`] = `
+"\\"use strict\\";
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Foo = function (_React$PureComponent) {
   _inherits(Foo, _React$PureComponent);
@@ -19,9 +21,9 @@ var Foo = function (_React$PureComponent) {
   }
 
   _createClass(Foo, [{
-    key: \"render\",
+    key: \\"render\\",
     value: function render() {
-      return React.createElement(\"div\", null);
+      return React.createElement(\\"div\\", null);
     }
   }]);
 
@@ -29,6 +31,6 @@ var Foo = function (_React$PureComponent) {
 }(React.PureComponent);
 
 Foo.propTypes = {
-  name: require(\"prop-types\").string.isRequired
+  name: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/import-and-loops-test.js.snap
+++ b/src/__tests__/__snapshots__/import-and-loops-test.js.snap
@@ -1,22 +1,24 @@
-exports[`test import-and-loops 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`import-and-loops 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
     value: true
 });
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var babelPluginFlowReactPropTypes_proptype_ExternalType = require(\'../types\').babelPluginFlowReactPropTypes_proptype_ExternalType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_ExternalType = require('../types').babelPluginFlowReactPropTypes_proptype_ExternalType || require('prop-types').any;
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
     value: {
-        flag: require(\'prop-types\').bool.isRequired,
-        list: require(\'prop-types\').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === \'function\' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
+        flag: require('prop-types').bool.isRequired,
+        list: require('prop-types').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
     }
 });
 
@@ -26,21 +28,21 @@ var C = function C(_ref) {
         list = _ref.list;
 
     return flag ? _react2.default.createElement(
-        \'div\',
+        'div',
         null,
-        \'yes\'
+        'yes'
     ) : _react2.default.createElement(
         Select,
         null,
         list.map(function (e) {
-            return _react2.default.createElement(\'option\', { value: e.id, key: e.id });
+            return _react2.default.createElement('option', { value: e.id, key: e.id });
         })
     );
 };
 
 C.propTypes = {
-    flag: require(\'prop-types\').bool.isRequired,
-    list: require(\'prop-types\').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === \'function\' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
+    flag: require('prop-types').bool.isRequired,
+    list: require('prop-types').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/import-non-relative.js.snap
+++ b/src/__tests__/__snapshots__/import-non-relative.js.snap
@@ -1,15 +1,17 @@
-exports[`test import-object 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`import-object 1`] = `
+"'use strict';
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\'foo\').babelPluginFlowReactPropTypes_proptype_NamedType || require(\'prop-types\').any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var babelPluginFlowReactPropTypes_proptype_DefaultType = require(\'bar\').babelPluginFlowReactPropTypes_proptype_DefaultType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require('foo').babelPluginFlowReactPropTypes_proptype_NamedType || require('prop-types').any;
+
+var babelPluginFlowReactPropTypes_proptype_DefaultType = require('bar').babelPluginFlowReactPropTypes_proptype_DefaultType || require('prop-types').any;
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -24,10 +26,10 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  an_imported_named_type: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \'function\' ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-  an_imported_default_type: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === \'function\' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_DefaultType).isRequired,
-  a_global_type: typeof Date === \'function\' ? require(\'prop-types\').instanceOf(Date).isRequired : require(\'prop-types\').any.isRequired,
-  a_undefined_type: typeof FooBarBaz === \'function\' ? require(\'prop-types\').instanceOf(FooBarBaz).isRequired : require(\'prop-types\').any.isRequired
+  an_imported_named_type: typeof babelPluginFlowReactPropTypes_proptype_NamedType === 'function' ? babelPluginFlowReactPropTypes_proptype_NamedType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  an_imported_default_type: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === 'function' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_DefaultType).isRequired,
+  a_global_type: typeof Date === 'function' ? require('prop-types').instanceOf(Date).isRequired : require('prop-types').any.isRequired,
+  a_undefined_type: typeof FooBarBaz === 'function' ? require('prop-types').instanceOf(FooBarBaz).isRequired : require('prop-types').any.isRequired
 };
 ;"
 `;

--- a/src/__tests__/__snapshots__/import-object-test.js.snap
+++ b/src/__tests__/__snapshots__/import-object-test.js.snap
@@ -1,15 +1,17 @@
-exports[`test import-object 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`import-object 1`] = `
+"'use strict';
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\'./foo\').babelPluginFlowReactPropTypes_proptype_NamedType || require(\'prop-types\').any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var babelPluginFlowReactPropTypes_proptype_DefaultType = require(\'./bar\').babelPluginFlowReactPropTypes_proptype_DefaultType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require('./foo').babelPluginFlowReactPropTypes_proptype_NamedType || require('prop-types').any;
+
+var babelPluginFlowReactPropTypes_proptype_DefaultType = require('./bar').babelPluginFlowReactPropTypes_proptype_DefaultType || require('prop-types').any;
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -24,12 +26,12 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  an_imported_named_type: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \'function\' ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-  an_imported_default_type: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === \'function\' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_DefaultType).isRequired,
-  optional_property: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \'function\' ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_NamedType),
-  can_be_null_property: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === \'function\' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require(\'prop-types\').shape(babelPluginFlowReactPropTypes_proptype_DefaultType),
-  a_global_type: typeof Date === \'function\' ? require(\'prop-types\').instanceOf(Date).isRequired : require(\'prop-types\').any.isRequired,
-  a_undefined_type: typeof FooBarBaz === \'function\' ? require(\'prop-types\').instanceOf(FooBarBaz).isRequired : require(\'prop-types\').any.isRequired
+  an_imported_named_type: typeof babelPluginFlowReactPropTypes_proptype_NamedType === 'function' ? babelPluginFlowReactPropTypes_proptype_NamedType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  an_imported_default_type: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === 'function' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_DefaultType).isRequired,
+  optional_property: typeof babelPluginFlowReactPropTypes_proptype_NamedType === 'function' ? babelPluginFlowReactPropTypes_proptype_NamedType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_NamedType),
+  can_be_null_property: typeof babelPluginFlowReactPropTypes_proptype_DefaultType === 'function' ? babelPluginFlowReactPropTypes_proptype_DefaultType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_DefaultType),
+  a_global_type: typeof Date === 'function' ? require('prop-types').instanceOf(Date).isRequired : require('prop-types').any.isRequired,
+  a_undefined_type: typeof FooBarBaz === 'function' ? require('prop-types').instanceOf(FooBarBaz).isRequired : require('prop-types').any.isRequired
 };
 ;"
 `;

--- a/src/__tests__/__snapshots__/indirect-jsx-test.js.snap
+++ b/src/__tests__/__snapshots__/indirect-jsx-test.js.snap
@@ -1,14 +1,16 @@
-exports[`test indirect-jsx 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`indirect-jsx 1`] = `
+"\\"use strict\\";
 
 var C = function C(props) {
   var el = null;
   if (true) {
-    el = React.createElement(\"div\", null);
+    el = React.createElement(\\"div\\", null);
   }
   return el;
 };
 C.propTypes = {
-  name: require(\"prop-types\").string.isRequired
+  name: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
+++ b/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
@@ -1,19 +1,21 @@
-exports[`test instance-of 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _some_class = require(\'./some_class\');
+exports[`instance-of 1`] = `
+"'use strict';
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _some_class = require('./some_class');
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_Fact\', {
-  value: typeof (Foo.Bar == null ? {} : Foo.Bar) === \'function\' ? require(\'prop-types\').instanceOf(Foo.Bar == null ? {} : Foo.Bar) : require(\'prop-types\').any
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Fact', {
+  value: typeof (Foo.Bar == null ? {} : Foo.Bar) === 'function' ? require('prop-types').instanceOf(Foo.Bar == null ? {} : Foo.Bar) : require('prop-types').any
 });
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_FactMap\', {
-  value: typeof (Foo.Map == null ? {} : Foo.Map) === \'function\' ? require(\'prop-types\').instanceOf(Foo.Map == null ? {} : Foo.Map) : require(\'prop-types\').any
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_FactMap', {
+  value: typeof (Foo.Map == null ? {} : Foo.Map) === 'function' ? require('prop-types').instanceOf(Foo.Map == null ? {} : Foo.Map) : require('prop-types').any
 });
 
 var MyComponent = function (_React$Component) {
@@ -29,8 +31,8 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  some_class: typeof (_some_class.SomeClass.property == null ? {} : _some_class.SomeClass.property) === \'function\' ? require(\'prop-types\').instanceOf(_some_class.SomeClass.property == null ? {} : _some_class.SomeClass.property).isRequired : require(\'prop-types\').any.isRequired,
-  generics: typeof (_some_class.SomeClass.Map == null ? {} : _some_class.SomeClass.Map) === \'function\' ? require(\'prop-types\').instanceOf(_some_class.SomeClass.Map == null ? {} : _some_class.SomeClass.Map).isRequired : require(\'prop-types\').any.isRequired,
-  deep: typeof (((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar == null ? {} : ((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar) === \'function\' ? require(\'prop-types\').instanceOf(((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar == null ? {} : ((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar).isRequired : require(\'prop-types\').any.isRequired
+  some_class: typeof (_some_class.SomeClass.property == null ? {} : _some_class.SomeClass.property) === 'function' ? require('prop-types').instanceOf(_some_class.SomeClass.property == null ? {} : _some_class.SomeClass.property).isRequired : require('prop-types').any.isRequired,
+  generics: typeof (_some_class.SomeClass.Map == null ? {} : _some_class.SomeClass.Map) === 'function' ? require('prop-types').instanceOf(_some_class.SomeClass.Map == null ? {} : _some_class.SomeClass.Map).isRequired : require('prop-types').any.isRequired,
+  deep: typeof (((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar == null ? {} : ((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar) === 'function' ? require('prop-types').instanceOf(((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar == null ? {} : ((_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting == null ? {} : (_some_class.SomeClass.deeper == null ? {} : _some_class.SomeClass.deeper).nesting).Bar).isRequired : require('prop-types').any.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/instance-of.js.snap
+++ b/src/__tests__/__snapshots__/instance-of.js.snap
@@ -1,17 +1,19 @@
-exports[`test instance-of 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _some_class = require(\'./some_class\');
+exports[`instance-of 1`] = `
+"'use strict';
+
+var _some_class = require('./some_class');
 
 var _some_class2 = _interopRequireDefault(_some_class);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
 var SomeOtherClass = function SomeOtherClass() {
   _classCallCheck(this, SomeOtherClass);
@@ -30,9 +32,9 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  some_class: typeof _some_class2.default === \'function\' ? require(\'prop-types\').instanceOf(_some_class2.default).isRequired : require(\'prop-types\').any.isRequired,
-  some_other_class: typeof SomeOtherClass === \'function\' ? require(\'prop-types\').instanceOf(SomeOtherClass).isRequired : require(\'prop-types\').any.isRequired,
-  key_can_be_omitted: typeof _some_class2.default === \'function\' ? require(\'prop-types\').instanceOf(_some_class2.default) : require(\'prop-types\').any,
-  value_can_be_null: typeof SomeOtherClass === \'function\' ? require(\'prop-types\').instanceOf(SomeOtherClass) : require(\'prop-types\').any
+  some_class: typeof _some_class2.default === 'function' ? require('prop-types').instanceOf(_some_class2.default).isRequired : require('prop-types').any.isRequired,
+  some_other_class: typeof SomeOtherClass === 'function' ? require('prop-types').instanceOf(SomeOtherClass).isRequired : require('prop-types').any.isRequired,
+  key_can_be_omitted: typeof _some_class2.default === 'function' ? require('prop-types').instanceOf(_some_class2.default) : require('prop-types').any,
+  value_can_be_null: typeof SomeOtherClass === 'function' ? require('prop-types').instanceOf(SomeOtherClass) : require('prop-types').any
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-complex-example.js.snap
@@ -1,40 +1,42 @@
-exports[`test intersection-exported-type-alias-unexported-object-literal 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-exported-type-alias-unexported-object-literal 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
-var babelPluginFlowReactPropTypes_proptype_DefaultType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_DefaultType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_DefaultType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_DefaultType || require(\\"prop-types\\").any;
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_T\", {
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_T\\", {
   value: {
-    foo: require(\"prop-types\").string.isRequired
+    foo: require(\\"prop-types\\").string.isRequired
   }
 });
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_U\", {
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_U\\", {
   value: {
-    bar: require(\"prop-types\").number.isRequired
+    bar: require(\\"prop-types\\").number.isRequired
   }
 });
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_X\", {
-  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-    a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \"function\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\"prop-types\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-    b: require(\"prop-types\").string.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
-    bar: require(\"prop-types\").number.isRequired
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
+  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+    a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+    b: require(\\"prop-types\\").string.isRequired
+  }, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
+    bar: require(\\"prop-types\\").number.isRequired
   }, {
-    foo: require(\"prop-types\").string.isRequired
+    foo: require(\\"prop-types\\").string.isRequired
   })
 });
 
@@ -51,20 +53,20 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  qux: require(\"prop-types\").string.isRequired,
-  quy: require(\"prop-types\").shape(Object.assign({}, {
-    foo: require(\"prop-types\").string.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-    XXX: require(\"prop-types\").string.isRequired,
-    YYY: require(\"prop-types\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-      ZZZ: require(\"prop-types\").number.isRequired
+  qux: require(\\"prop-types\\").string.isRequired,
+  quy: require(\\"prop-types\\").shape(Object.assign({}, {
+    foo: require(\\"prop-types\\").string.isRequired
+  }, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+    XXX: require(\\"prop-types\\").string.isRequired,
+    YYY: require(\\"prop-types\\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+      ZZZ: require(\\"prop-types\\").number.isRequired
     })).isRequired
   })).isRequired,
-  quz: require(\"prop-types\").shape(Object.assign({}, {
-    bar: require(\"prop-types\").number.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType)).isRequired,
-  bar: require(\"prop-types\").number.isRequired,
-  foo: require(\"prop-types\").string.isRequired
+  quz: require(\\"prop-types\\").shape(Object.assign({}, {
+    bar: require(\\"prop-types\\").number.isRequired
+  }, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType)).isRequired,
+  bar: require(\\"prop-types\\").number.isRequired,
+  foo: require(\\"prop-types\\").string.isRequired
 };
 
 var D = function (_React$Component2) {
@@ -80,15 +82,15 @@ var D = function (_React$Component2) {
 }(React.Component);
 
 D.propTypes = Object.assign({}, {
-  c: require(\"prop-types\").string.isRequired,
-  b: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \"function\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\"prop-types\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired
-}, Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-  a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \"function\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\"prop-types\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-  b: require(\"prop-types\").string.isRequired
-}, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
-  bar: require(\"prop-types\").number.isRequired
+  c: require(\\"prop-types\\").string.isRequired,
+  b: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired
+}, Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+  a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  b: require(\\"prop-types\\").string.isRequired
+}, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
+  bar: require(\\"prop-types\\").number.isRequired
 }, {
-  foo: require(\"prop-types\").string.isRequired
+  foo: require(\\"prop-types\\").string.isRequired
 }));
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/intersection-deeply-nested.js.snap
+++ b/src/__tests__/__snapshots__/intersection-deeply-nested.js.snap
@@ -1,23 +1,25 @@
-exports[`test intersection-exported-type-alias-unexported-object-literal 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-exported-type-alias-unexported-object-literal 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-var babelPluginFlowReactPropTypes_proptype_ThirdNamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_ThirdNamedType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_ThirdNamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_ThirdNamedType || require(\\"prop-types\\").any;
 
-var babelPluginFlowReactPropTypes_proptype_OtherNamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_OtherNamedType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_OtherNamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_OtherNamedType || require(\\"prop-types\\").any;
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
 var D = function (_React$Component) {
   _inherits(D, _React$Component);
@@ -31,13 +33,13 @@ var D = function (_React$Component) {
   return D;
 }(React.Component);
 
-D.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-  foo: require(\"prop-types\").number.isRequired,
-  bar: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \"function\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\"prop-types\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-  baz: require(\"prop-types\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_OtherNamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_OtherNamedType, {
-    foo: require(\"prop-types\").oneOf([\"number\"]).isRequired,
-    bar: require(\"prop-types\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_OtherNamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_OtherNamedType)).isRequired
-  }, babelPluginFlowReactPropTypes_proptype_ThirdNamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_ThirdNamedType)).isRequired
+D.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+  foo: require(\\"prop-types\\").number.isRequired,
+  bar: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  baz: require(\\"prop-types\\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_OtherNamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_OtherNamedType, {
+    foo: require(\\"prop-types\\").oneOf([\\"number\\"]).isRequired,
+    bar: require(\\"prop-types\\").shape(Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_OtherNamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_OtherNamedType)).isRequired
+  }, babelPluginFlowReactPropTypes_proptype_ThirdNamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_ThirdNamedType)).isRequired
 });
 ;
 

--- a/src/__tests__/__snapshots__/intersection-export-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-export-test.js.snap
@@ -1,23 +1,25 @@
-exports[`test interesection-export 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`interesection-export 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-var babelPluginFlowReactPropTypes_proptype_T = require(\'./T\').babelPluginFlowReactPropTypes_proptype_T || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_T = require('./T').babelPluginFlowReactPropTypes_proptype_T || require('prop-types').any;
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_U\', {
-  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
-    foo: require(\'prop-types\').string.isRequired
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
+  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
+    foo: require('prop-types').string.isRequired
   })
 });
 
@@ -33,8 +35,8 @@ var C = function (_React$Component) {
   return C;
 }(React.Component);
 
-C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
-  foo: require(\'prop-types\').string.isRequired
+C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
+  foo: require('prop-types').string.isRequired
 });
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/intersection-imported-object.js.snap
+++ b/src/__tests__/__snapshots__/intersection-imported-object.js.snap
@@ -1,13 +1,15 @@
-exports[`test intersection-with-imported-object 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection-with-imported-object 1`] = `
+"'use strict';
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\'./foo\').babelPluginFlowReactPropTypes_proptype_NamedType || require(\'prop-types\').any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var babelPluginFlowReactPropTypes_proptype_NamedType = require('./foo').babelPluginFlowReactPropTypes_proptype_NamedType || require('prop-types').any;
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -21,8 +23,8 @@ var C = function (_React$Component) {
   return C;
 }(React.Component);
 
-C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-  foo: require(\'prop-types\').string.isRequired,
-  bar: require(\'prop-types\').number.isRequired
+C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+  foo: require('prop-types').string.isRequired,
+  bar: require('prop-types').number.isRequired
 });"
 `;

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
@@ -1,17 +1,19 @@
-exports[`test intersection inline with exported and nested imported type 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection inline with exported and nested imported type 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\"prop-types\").any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_ExportedType\", {
+var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
+
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
   value: {
-    bar: require(\"prop-types\").number.isRequired
+    bar: require(\\"prop-types\\").number.isRequired
   }
 });
 
@@ -28,8 +30,8 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  foo: require(\"prop-types\").string.isRequired,
-  baz: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \"function\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\"prop-types\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-  bar: require(\"prop-types\").number.isRequired
+  foo: require(\\"prop-types\\").string.isRequired,
+  baz: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  bar: require(\\"prop-types\\").number.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
@@ -1,15 +1,17 @@
-exports[`test intersection inline with exported type 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection inline with exported type 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_ExportedType\", {
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
   value: {
-    bar: require(\"prop-types\").number.isRequired
+    bar: require(\\"prop-types\\").number.isRequired
   }
 });
 
@@ -26,7 +28,7 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  foo: require(\"prop-types\").string.isRequired,
-  bar: require(\"prop-types\").number.isRequired
+  foo: require(\\"prop-types\\").string.isRequired,
+  bar: require(\\"prop-types\\").number.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-inline-with-imported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-imported-type.js.snap
@@ -1,13 +1,15 @@
-exports[`test intersection inline with imported type 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection inline with imported type 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\"prop-types\").any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
 var MyComponent = function (_React$Component) {
   _inherits(MyComponent, _React$Component);
@@ -22,6 +24,6 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = Object.assign({}, {
-  foo: require(\"prop-types\").string.isRequired
-}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType);"
+  foo: require(\\"prop-types\\").string.isRequired
+}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType);"
 `;

--- a/src/__tests__/__snapshots__/intersection-inline-with-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-type-alias.js.snap
@@ -1,11 +1,13 @@
-exports[`test intersection inline without type alias 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection inline without type alias 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MyComponent = function (_React$Component) {
   _inherits(MyComponent, _React$Component);
@@ -20,7 +22,7 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  foo: require(\"prop-types\").string.isRequired,
-  bar: require(\"prop-types\").number.isRequired
+  foo: require(\\"prop-types\\").string.isRequired,
+  bar: require(\\"prop-types\\").number.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-inline-without-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-without-type-alias.js.snap
@@ -1,11 +1,13 @@
-exports[`test intersection inline without type alias 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection inline without type alias 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MyComponent = function (_React$Component) {
   _inherits(MyComponent, _React$Component);
@@ -20,7 +22,7 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-  foo: require(\"prop-types\").string.isRequired,
-  bar: require(\"prop-types\").number.isRequired
+  foo: require(\\"prop-types\\").string.isRequired,
+  bar: require(\\"prop-types\\").number.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
@@ -1,23 +1,25 @@
-exports[`test intersection-exported-type-alias-unexported-object-literal 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-exported-type-alias-unexported-object-literal 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
    value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\"./types\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\"prop-types\").any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
-if (typeof exports !== \"undefined\") Object.defineProperty(exports, \"babelPluginFlowReactPropTypes_proptype_X\", {
-   value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-      a: require(\"prop-types\").string.isRequired
+if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
+   value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+      a: require(\\"prop-types\\").string.isRequired
    })
 });
 
@@ -33,10 +35,10 @@ var D = function (_React$Component) {
    return D;
 }(React.Component);
 
-D.propTypes = Object.assign({}, Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\"prop-types\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-   a: require(\"prop-types\").string.isRequired
+D.propTypes = Object.assign({}, Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+   a: require(\\"prop-types\\").string.isRequired
 }), {
-   c: require(\"prop-types\").string.isRequired
+   c: require(\\"prop-types\\").string.isRequired
 });
 ;
 

--- a/src/__tests__/__snapshots__/intersection-nested-imported-object.js.snap
+++ b/src/__tests__/__snapshots__/intersection-nested-imported-object.js.snap
@@ -1,13 +1,15 @@
-exports[`test intersection-nested-with-imported-object 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection-nested-with-imported-object 1`] = `
+"'use strict';
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\'./foo\').babelPluginFlowReactPropTypes_proptype_NamedType || require(\'prop-types\').any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var babelPluginFlowReactPropTypes_proptype_NamedType = require('./foo').babelPluginFlowReactPropTypes_proptype_NamedType || require('prop-types').any;
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -22,10 +24,10 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  foo: require(\'prop-types\').string.isRequired,
-  bar: require(\'prop-types\').number.isRequired,
-  baz: require(\'prop-types\').shape(Object.assign({}, {
-    foo: require(\'prop-types\').number.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_NamedType === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType)).isRequired
+  foo: require('prop-types').string.isRequired,
+  bar: require('prop-types').number.isRequired,
+  baz: require('prop-types').shape(Object.assign({}, {
+    foo: require('prop-types').number.isRequired
+  }, babelPluginFlowReactPropTypes_proptype_NamedType === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType)).isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-object-type-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-object-type-literal-type-alias.js.snap
@@ -1,17 +1,19 @@
-exports[`test intersection-object-type-literal-type-alias 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-object-type-literal-type-alias 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
 ;
 
@@ -28,8 +30,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  bar: require(\'prop-types\').string.isRequired,
-  foo: require(\'prop-types\').string.isRequired
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/intersection-only-imported-objects.js.snap
+++ b/src/__tests__/__snapshots__/intersection-only-imported-objects.js.snap
@@ -1,15 +1,17 @@
-exports[`test intersection-with-only-imported-objects 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection-with-only-imported-objects 1`] = `
+"'use strict';
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-var babelPluginFlowReactPropTypes_proptype_NamedType = require(\'./foo\').babelPluginFlowReactPropTypes_proptype_NamedType || require(\'prop-types\').any;
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var babelPluginFlowReactPropTypes_proptype_SomeOtherType = require(\'./bar\').babelPluginFlowReactPropTypes_proptype_SomeOtherType || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_NamedType = require('./foo').babelPluginFlowReactPropTypes_proptype_NamedType || require('prop-types').any;
+
+var babelPluginFlowReactPropTypes_proptype_SomeOtherType = require('./bar').babelPluginFlowReactPropTypes_proptype_SomeOtherType || require('prop-types').any;
 
 var C = function (_React$Component) {
     _inherits(C, _React$Component);
@@ -23,5 +25,5 @@ var C = function (_React$Component) {
     return C;
 }(React.Component);
 
-C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_SomeOtherType === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_SomeOtherType);"
+C.propTypes = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, babelPluginFlowReactPropTypes_proptype_SomeOtherType === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_SomeOtherType);"
 `;

--- a/src/__tests__/__snapshots__/intersection-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-test.js.snap
@@ -1,11 +1,13 @@
-exports[`test intersection 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`intersection 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MyComponent = function (_React$Component) {
     _inherits(MyComponent, _React$Component);
@@ -20,6 +22,6 @@ var MyComponent = function (_React$Component) {
 }(React.Component);
 
 MyComponent.propTypes = {
-    someProp: require(\"prop-types\").any.isRequired
+    someProp: require(\\"prop-types\\").any.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
@@ -1,22 +1,24 @@
-exports[`test interesection-two-object-type-literals 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`interesection-two-object-type-literals 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_U\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: {
-    bar: require(\'prop-types\').string.isRequired,
-    foo: require(\'prop-types\').string.isRequired
+    bar: require('prop-types').string.isRequired,
+    foo: require('prop-types').string.isRequired
   }
 });
 
@@ -33,8 +35,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  bar: require(\'prop-types\').string.isRequired,
-  foo: require(\'prop-types\').string.isRequired
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -1,21 +1,23 @@
-exports[`test intersection-exported-type-alias-unexported-object-literal 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-exported-type-alias-unexported-object-literal 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_T\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: {
-    bar: require(\'prop-types\').string.isRequired
+    bar: require('prop-types').string.isRequired
   }
 });
 
@@ -32,8 +34,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  bar: require(\'prop-types\').string.isRequired,
-  foo: require(\'prop-types\').string.isRequired
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/intersection-two-object-type-literals.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-object-type-literals.js.snap
@@ -1,17 +1,19 @@
-exports[`test intersection-two-object-type-literals 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`intersection-two-object-type-literals 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
 var C = function (_React$Component) {
   _inherits(C, _React$Component);
@@ -26,8 +28,8 @@ var C = function (_React$Component) {
 }(React.Component);
 
 C.propTypes = {
-  bar: require(\'prop-types\').string.isRequired,
-  foo: require(\'prop-types\').string.isRequired
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
 };
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/just-exports-test.js.snap
+++ b/src/__tests__/__snapshots__/just-exports-test.js.snap
@@ -1,24 +1,26 @@
-exports[`test just-exports 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`just-exports 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.production = exports.baseUrl = exports.assets = exports.appcache = undefined;
 
-var _appcache2 = require(\"./validators/appcache.js\");
+var _appcache2 = require(\\"./validators/appcache.js\\");
 
 var _appcache3 = _interopRequireDefault(_appcache2);
 
-var _assets2 = require(\"./validators/assets.js\");
+var _assets2 = require(\\"./validators/assets.js\\");
 
 var _assets3 = _interopRequireDefault(_assets2);
 
-var _baseUrl2 = require(\"./validators/baseUrl.js\");
+var _baseUrl2 = require(\\"./validators/baseUrl.js\\");
 
 var _baseUrl3 = _interopRequireDefault(_baseUrl2);
 
-var _production2 = require(\"./validators/production.js\");
+var _production2 = require(\\"./validators/production.js\\");
 
 var _production3 = _interopRequireDefault(_production2);
 

--- a/src/__tests__/__snapshots__/literal-type-annotation-test.js.snap
+++ b/src/__tests__/__snapshots__/literal-type-annotation-test.js.snap
@@ -1,13 +1,15 @@
-exports[`test literal-type-annotation 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+exports[`literal-type-annotation 1`] = `
+"'use strict';
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Foo = function (_Component) {
   _inherits(Foo, _Component);
@@ -19,9 +21,9 @@ var Foo = function (_Component) {
   }
 
   _createClass(Foo, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
-      return React.createElement(\'div\', null);
+      return React.createElement('div', null);
     }
   }]);
 
@@ -29,12 +31,12 @@ var Foo = function (_Component) {
 }(Component);
 
 Foo.propTypes = {
-  a_string: require(\'prop-types\').oneOf([\'str\']).isRequired,
-  a_number: require(\'prop-types\').oneOf([7]).isRequired,
-  a_boolean: require(\'prop-types\').oneOf([true]).isRequired,
-  a_null: require(\'prop-types\').oneOf([true]).isRequired,
+  a_string: require('prop-types').oneOf(['str']).isRequired,
+  a_number: require('prop-types').oneOf([7]).isRequired,
+  a_boolean: require('prop-types').oneOf([true]).isRequired,
+  a_null: require('prop-types').oneOf([true]).isRequired,
   a_void: function a_void(props, propName, componentName) {
-    if (props[propName] != null) return new Error(\'Invalid prop \`\' + propName + \'\` of value \`\' + value + \'\` passed to \`\' + componentName + \'\`. Expected undefined or null.\');
+    if (props[propName] != null) return new Error('Invalid prop \`' + propName + '\` of value \`' + value + '\` passed to \`' + componentName + '\`. Expected undefined or null.');
   }
 };"
 `;

--- a/src/__tests__/__snapshots__/no-type-test.js.snap
+++ b/src/__tests__/__snapshots__/no-type-test.js.snap
@@ -1,11 +1,13 @@
-exports[`test no-type 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+exports[`no-type 1`] = `
+"\\"use strict\\";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var X = function (_React$Component) {
   _inherits(X, _React$Component);

--- a/src/__tests__/__snapshots__/non-component-functions-test.js.snap
+++ b/src/__tests__/__snapshots__/non-component-functions-test.js.snap
@@ -1,5 +1,7 @@
-exports[`test function-types 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function-types 1`] = `
+"\\"use strict\\";
 
 var NotComponent = function NotComponent(x, y) {
   return x + y;

--- a/src/__tests__/__snapshots__/nullable-test.js.snap
+++ b/src/__tests__/__snapshots__/nullable-test.js.snap
@@ -1,17 +1,19 @@
-exports[`test nullable 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`nullable 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);
@@ -26,7 +28,7 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  foo: require(\'prop-types\').string
+  foo: require('prop-types').string
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/object-props-test.js.snap
+++ b/src/__tests__/__snapshots__/object-props-test.js.snap
@@ -1,7 +1,9 @@
-exports[`test object-props 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`object-props 1`] = `
+"\\"use strict\\";
 
 var Component = function Component(props) {
-  return React.createElement(\"div\", null);
+  return React.createElement(\\"div\\", null);
 };"
 `;

--- a/src/__tests__/__snapshots__/pure-component-test.js.snap
+++ b/src/__tests__/__snapshots__/pure-component-test.js.snap
@@ -1,13 +1,15 @@
-exports[`test pure-component 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+exports[`pure-component 1`] = `
+"\\"use strict\\";
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Foo = function (_React$PureComponent) {
   _inherits(Foo, _React$PureComponent);
@@ -19,9 +21,9 @@ var Foo = function (_React$PureComponent) {
   }
 
   _createClass(Foo, [{
-    key: \"render\",
+    key: \\"render\\",
     value: function render() {
-      return React.createElement(\"div\", null);
+      return React.createElement(\\"div\\", null);
     }
   }]);
 
@@ -29,6 +31,6 @@ var Foo = function (_React$PureComponent) {
 }(React.PureComponent);
 
 Foo.propTypes = {
-  name: require(\"prop-types\").string.isRequired
+  name: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/real-test.js.snap
+++ b/src/__tests__/__snapshots__/real-test.js.snap
@@ -1,23 +1,26 @@
-exports[`test real 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`real 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
+exports.default = undefined;
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var AlbumCard = function (_React$Component) {
   _inherits(AlbumCard, _React$Component);
@@ -29,7 +32,7 @@ var AlbumCard = function (_React$Component) {
   }
 
   _createClass(AlbumCard, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
       return _react2.default.createElement(Box, null);
     }
@@ -39,23 +42,23 @@ var AlbumCard = function (_React$Component) {
 }(_react2.default.Component);
 
 AlbumCard.propTypes = {
-  data: require(\'prop-types\').shape({
-    stats: require(\'prop-types\').shape({
-      images: require(\'prop-types\').number.isRequired,
-      videos: require(\'prop-types\').number.isRequired,
-      reposts: require(\'prop-types\').number.isRequired,
-      shares: require(\'prop-types\').number.isRequired,
-      stashes: require(\'prop-types\').number.isRequired,
-      likes: require(\'prop-types\').number.isRequired,
-      comments: require(\'prop-types\').number.isRequired
+  data: require('prop-types').shape({
+    stats: require('prop-types').shape({
+      images: require('prop-types').number.isRequired,
+      videos: require('prop-types').number.isRequired,
+      reposts: require('prop-types').number.isRequired,
+      shares: require('prop-types').number.isRequired,
+      stashes: require('prop-types').number.isRequired,
+      likes: require('prop-types').number.isRequired,
+      comments: require('prop-types').number.isRequired
     }).isRequired,
-    title: require(\'prop-types\').string.isRequired,
-    coverImage: require(\'prop-types\').shape({
-      id: require(\'prop-types\').string.isRequired,
-      src: require(\'prop-types\').string.isRequired
+    title: require('prop-types').string.isRequired,
+    coverImage: require('prop-types').shape({
+      id: require('prop-types').string.isRequired,
+      src: require('prop-types').string.isRequired
     }).isRequired,
-    description: require(\'prop-types\').string.isRequired,
-    userIsFollowing: require(\'prop-types\').oneOf([true, false]).isRequired
+    description: require('prop-types').string.isRequired,
+    userIsFollowing: require('prop-types').oneOf([true, false]).isRequired
   }).isRequired
 };
 exports.default = AlbumCard;"

--- a/src/__tests__/__snapshots__/render-imported-non-shape-types-generate-warnings.js.snap
+++ b/src/__tests__/__snapshots__/render-imported-non-shape-types-generate-warnings.js.snap
@@ -1,6 +1,8 @@
-exports[`test imported-non-shape-generates-warnings: correct types, no warning types given 1`] = `Array []`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test imported-non-shape-generates-warnings: incorrect types given 1`] = `
+exports[`imported-non-shape-generates-warnings: correct types, no warning types given 1`] = `Array []`;
+
+exports[`imported-non-shape-generates-warnings: incorrect types given 1`] = `
 Array [
   Array [
     "Warning: Failed prop type: Invalid prop \`stringValue\` of type \`number\` supplied to \`C\`, expected \`string\`.
@@ -11,10 +13,10 @@ Array [
     in C",
   ],
   Array [
-    "Warning: Failed prop type: Invalid prop \`enumStringValue\` of value \`incorrect\` supplied to \`C\`, expected one of [\"yes\",\"no\"].
+    "Warning: Failed prop type: Invalid prop \`enumStringValue\` of value \`incorrect\` supplied to \`C\`, expected one of [\\"yes\\",\\"no\\"].
     in C",
   ],
 ]
 `;
 
-exports[`test imported-non-shape-generates-warnings: no props given 1`] = `Array []`;
+exports[`imported-non-shape-generates-warnings: no props given 1`] = `Array []`;

--- a/src/__tests__/__snapshots__/render-intersection-imported-object-generates-warnings.js.snap
+++ b/src/__tests__/__snapshots__/render-intersection-imported-object-generates-warnings.js.snap
@@ -1,4 +1,6 @@
-exports[`test intersection-with-imported-object-generates-warnings 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`intersection-with-imported-object-generates-warnings 1`] = `
 Array [
   Array [
     "Warning: Failed prop type: The prop \`baz\` is marked as required in \`C\`, but its value is \`undefined\`.

--- a/src/__tests__/__snapshots__/render-intersection-nested-imported-object-generates-warnings.js.snap
+++ b/src/__tests__/__snapshots__/render-intersection-nested-imported-object-generates-warnings.js.snap
@@ -1,6 +1,8 @@
-exports[`test intersection-with-imported-object-generates-warnings: No warnings, all props given correctly 1`] = `Array []`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test intersection-with-imported-object-generates-warnings: invalid value given for key quy.baz 1`] = `
+exports[`intersection-with-imported-object-generates-warnings: No warnings, all props given correctly 1`] = `Array []`;
+
+exports[`intersection-with-imported-object-generates-warnings: invalid value given for key quy.baz 1`] = `
 Array [
   Array [
     "Warning: Failed prop type: Invalid prop \`quy.baz\` of type \`number\` supplied to \`C\`, expected \`string\`.
@@ -9,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`test intersection-with-imported-object-generates-warnings: no prop types given 1`] = `
+exports[`intersection-with-imported-object-generates-warnings: no prop types given 1`] = `
 Array [
   Array [
     "Warning: Failed prop type: The prop \`qux\` is marked as required in \`C\`, but its value is \`undefined\`.
@@ -42,7 +44,7 @@ Array [
 ]
 `;
 
-exports[`test intersection-with-imported-object-generates-warnings: null given for nested shape quy 1`] = `
+exports[`intersection-with-imported-object-generates-warnings: null given for nested shape quy 1`] = `
 Array [
   Array [
     "Warning: Failed prop type: The prop \`quy\` is marked as required in \`C\`, but its value is \`null\`.
@@ -51,7 +53,7 @@ Array [
 ]
 `;
 
-exports[`test intersection-with-imported-object-generates-warnings: test deeper nested type quz.bar: specified with wrong type  1`] = `
+exports[`intersection-with-imported-object-generates-warnings: test deeper nested type quz.bar: specified with wrong type  1`] = `
 Array [
   Array [
     "Warning: Failed prop type: Invalid prop \`quz.bar.baz\` of type \`number\` supplied to \`C\`, expected \`string\`.
@@ -60,7 +62,7 @@ Array [
 ]
 `;
 
-exports[`test intersection-with-imported-object-generates-warnings: test deeper nested type quz: missing bar: TestType  1`] = `
+exports[`intersection-with-imported-object-generates-warnings: test deeper nested type quz: missing bar: TestType  1`] = `
 Array [
   Array [
     "Warning: Failed prop type: The prop \`quz.bar\` is marked as required in \`C\`, but its value is \`undefined\`.

--- a/src/__tests__/__snapshots__/stateless-arrow-body-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-arrow-body-test.js.snap
@@ -1,11 +1,13 @@
-exports[`test stateless-arrow-body 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-arrow-body 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var React = require(\'react\');
+var React = require('react');
 
 var arrowFunctionWithBody = function arrowFunctionWithBody() {
   return window.console;
@@ -13,25 +15,25 @@ var arrowFunctionWithBody = function arrowFunctionWithBody() {
 
 var Foo = function Foo(props) {
   return React.createElement(
-    \'div\',
+    'div',
     null,
     props.x
   );
 };
 
 Foo.propTypes = {
-  x: require(\'prop-types\').oneOf([\'option1\', \'option2\'])
+  x: require('prop-types').oneOf(['option1', 'option2'])
 };
 var Bar = function Bar(props) {
   return React.createElement(
-    \'div\',
+    'div',
     null,
     props.x
   );
 };
 
 Bar.propTypes = {
-  x: require(\'prop-types\').oneOf([\'option1\', \'option2\'])
+  x: require('prop-types').oneOf(['option1', 'option2'])
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/stateless-arrow-body-without-jsx-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-arrow-body-without-jsx-test.js.snap
@@ -1,22 +1,24 @@
-exports[`test stateless-arrow-body-without-jsx 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-arrow-body-without-jsx 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var React = require(\'react\');
+var React = require('react');
 
 var arrowFunctionWithBody = function arrowFunctionWithBody() {
   return window.console;
 };
 
 var Foo = function Foo(props) {
-  return React.createElement(\'div\', null, props.x);
+  return React.createElement('div', null, props.x);
 };
 
 Foo.propTypes = {
-  x: require(\'prop-types\').oneOf([\'option1\', \'option2\'])
+  x: require('prop-types').oneOf(['option1', 'option2'])
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/stateless-arrow-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-arrow-test.js.snap
@@ -1,11 +1,13 @@
-exports[`test stateless-arrow 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-arrow 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var React = require(\'react\');
+var React = require('react');
 
 var arrowFunctionWithNoBody = function arrowFunctionWithNoBody() {
   return window.console;
@@ -13,14 +15,14 @@ var arrowFunctionWithNoBody = function arrowFunctionWithNoBody() {
 
 var Foo = function Foo(props) {
   React.createElement(
-    \'div\',
+    'div',
     null,
     props.x
   );
 };
 
 Foo.propTypes = {
-  x: require(\'prop-types\').oneOf([\'option1\', \'option2\'])
+  x: require('prop-types').oneOf(['option1', 'option2'])
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/stateless-exports-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-exports-test.js.snap
@@ -1,12 +1,14 @@
-exports[`test stateless-exports 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-exports 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.C2 = exports.C1 = undefined;
 
-var _react = require(\"react\");
+var _react = require(\\"react\\");
 
 var _react2 = _interopRequireDefault(_react);
 
@@ -15,17 +17,18 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var C1 = exports.C1 = function C1(_ref) {
   var m = _ref.m;
 
-  return _react2.default.createElement(\"div\", null);
+  return _react2.default.createElement(\\"div\\", null);
 };
+
 C1.propTypes = {
-  m: require(\"prop-types\").string.isRequired
+  m: require(\\"prop-types\\").string.isRequired
 };
 var C2 = exports.C2 = function C2(_ref2) {
   var m = _ref2.m;
 
-  return _react2.default.createElement(\"div\", null);
+  return _react2.default.createElement(\\"div\\", null);
 };
 C2.propTypes = {
-  m: require(\"prop-types\").string.isRequired
+  m: require(\\"prop-types\\").string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/stateless-inline-defaults-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-inline-defaults-test.js.snap
@@ -1,29 +1,31 @@
-exports[`test stateless-inline-defaults 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-inline-defaults 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.default = Foo;
 
-var React = require(\'react\');
+var React = require('react');
 
 function Foo(_ref) {
   var _ref$x = _ref.x,
       x = _ref$x === undefined ? 1 : _ref$x,
       _ref$y = _ref.y,
-      y = _ref$y === undefined ? \'foo\' : _ref$y;
+      y = _ref$y === undefined ? 'foo' : _ref$y;
 
   React.createElement(
-    \'div\',
+    'div',
     null,
     x,
-    \'/\',
+    '/',
     y
   );
 }
 Foo.propTypes = {
-  x: require(\'prop-types\').number,
-  y: require(\'prop-types\').string
+  x: require('prop-types').number,
+  y: require('prop-types').string
 };"
 `;

--- a/src/__tests__/__snapshots__/stateless-inline-imports-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-inline-imports-test.js.snap
@@ -1,20 +1,22 @@
-exports[`test stateless-inline-imports 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-var _react = require(\'react\');
+exports[`stateless-inline-imports 1`] = `
+"'use strict';
+
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var babelPluginFlowReactPropTypes_proptype_T = require(\'../types\').babelPluginFlowReactPropTypes_proptype_T || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_T = require('../types').babelPluginFlowReactPropTypes_proptype_T || require('prop-types').any;
 
 var C = function C(props) {
   _react2.default.createElement(
-    \'div\',
+    'div',
     null,
     props.name
   );
 };
-C.propTypes = babelPluginFlowReactPropTypes_proptype_T === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_T;"
+C.propTypes = babelPluginFlowReactPropTypes_proptype_T === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_T;"
 `;

--- a/src/__tests__/__snapshots__/stateless-inline-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-inline-test.js.snap
@@ -1,42 +1,44 @@
-exports[`test stateless-inline 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-inline 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.default = Foo;
 
-var React = require(\'react\');
+var React = require('react');
 
 function Foo(props) {
   var x = props.a_number;
   return React.createElement(
-    \'div\',
+    'div',
     null,
     x
   );
 }
 Foo.propTypes = {
-  an_optional_string: require(\'prop-types\').string,
-  a_number: require(\'prop-types\').number.isRequired,
-  a_boolean: require(\'prop-types\').bool.isRequired,
-  a_generic_object: require(\'prop-types\').object.isRequired,
-  array_of_strings: require(\'prop-types\').arrayOf(require(\'prop-types\').string).isRequired,
-  instance_of_Bar: typeof Bar === \'function\' ? require(\'prop-types\').instanceOf(Bar).isRequired : require(\'prop-types\').any.isRequired,
-  anything: require(\'prop-types\').any.isRequired,
-  one_of: require(\'prop-types\').oneOf([\'QUACK\', \'BARK\', 5]).isRequired,
-  onw_of_type: require(\'prop-types\').oneOfType([require(\'prop-types\').number, require(\'prop-types\').string]).isRequired,
-  nested_object_level_1: require(\'prop-types\').shape({
-    string_property_1: require(\'prop-types\').string.isRequired,
-    nested_object_level_2: require(\'prop-types\').shape({
-      nested_object_level_3: require(\'prop-types\').shape({
-        string_property_3: require(\'prop-types\').string.isRequired
+  an_optional_string: require('prop-types').string,
+  a_number: require('prop-types').number.isRequired,
+  a_boolean: require('prop-types').bool.isRequired,
+  a_generic_object: require('prop-types').object.isRequired,
+  array_of_strings: require('prop-types').arrayOf(require('prop-types').string).isRequired,
+  instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
+  anything: require('prop-types').any.isRequired,
+  one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,
+  onw_of_type: require('prop-types').oneOfType([require('prop-types').number, require('prop-types').string]).isRequired,
+  nested_object_level_1: require('prop-types').shape({
+    string_property_1: require('prop-types').string.isRequired,
+    nested_object_level_2: require('prop-types').shape({
+      nested_object_level_3: require('prop-types').shape({
+        string_property_3: require('prop-types').string.isRequired
       }).isRequired,
-      string_property_2: require(\'prop-types\').string.isRequired
+      string_property_2: require('prop-types').string.isRequired
     }).isRequired
   }).isRequired,
   should_error_if_provided: function should_error_if_provided(props, propName, componentName) {
-    if (props[propName] != null) return new Error(\'Invalid prop \`\' + propName + \'\` of value \`\' + value + \'\` passed to \`\' + componentName + \'\`. Expected undefined or null.\');
+    if (props[propName] != null) return new Error('Invalid prop \`' + propName + '\` of value \`' + value + '\` passed to \`' + componentName + '\`. Expected undefined or null.');
   }
 };"
 `;

--- a/src/__tests__/__snapshots__/stateless-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-test.js.snap
@@ -1,41 +1,43 @@
-exports[`test stateless 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.default = Foo;
 
-var React = require(\'react\');
+var React = require('react');
 
 function Foo(props) {
-  React.createElement(\'div\', null);
+  React.createElement('div', null);
 }
 Foo.propTypes = {
-  an_optional_string: require(\'prop-types\').string,
-  an_optional_string_1: require(\'prop-types\').string,
-  an_optional_union: require(\'prop-types\').oneOf([1, 10, \'foo\']),
-  an_optional_union_1: require(\'prop-types\').oneOf([1, 10, \'foo\']),
-  an_optional_union_2: require(\'prop-types\').oneOfType([require(\'prop-types\').string, require(\'prop-types\').number]),
-  a_number: require(\'prop-types\').number.isRequired,
-  a_boolean: require(\'prop-types\').bool.isRequired,
-  a_generic_object: require(\'prop-types\').object.isRequired,
-  array_of_strings: require(\'prop-types\').arrayOf(require(\'prop-types\').string).isRequired,
-  instance_of_Bar: typeof Bar === \'function\' ? require(\'prop-types\').instanceOf(Bar).isRequired : require(\'prop-types\').any.isRequired,
-  anything: require(\'prop-types\').any.isRequired,
-  one_of: require(\'prop-types\').oneOf([\'QUACK\', \'BARK\', 5]).isRequired,
-  onw_of_type: require(\'prop-types\').oneOfType([require(\'prop-types\').number, require(\'prop-types\').string]).isRequired,
-  nested_object_level_1: require(\'prop-types\').shape({
-    string_property_1: require(\'prop-types\').string.isRequired,
-    nested_object_level_2: require(\'prop-types\').shape({
-      nested_object_level_3: require(\'prop-types\').shape({
-        string_property_3: require(\'prop-types\').string.isRequired
+  an_optional_string: require('prop-types').string,
+  an_optional_string_1: require('prop-types').string,
+  an_optional_union: require('prop-types').oneOf([1, 10, 'foo']),
+  an_optional_union_1: require('prop-types').oneOf([1, 10, 'foo']),
+  an_optional_union_2: require('prop-types').oneOfType([require('prop-types').string, require('prop-types').number]),
+  a_number: require('prop-types').number.isRequired,
+  a_boolean: require('prop-types').bool.isRequired,
+  a_generic_object: require('prop-types').object.isRequired,
+  array_of_strings: require('prop-types').arrayOf(require('prop-types').string).isRequired,
+  instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
+  anything: require('prop-types').any.isRequired,
+  one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,
+  onw_of_type: require('prop-types').oneOfType([require('prop-types').number, require('prop-types').string]).isRequired,
+  nested_object_level_1: require('prop-types').shape({
+    string_property_1: require('prop-types').string.isRequired,
+    nested_object_level_2: require('prop-types').shape({
+      nested_object_level_3: require('prop-types').shape({
+        string_property_3: require('prop-types').string.isRequired
       }).isRequired,
-      string_property_2: require(\'prop-types\').string.isRequired
+      string_property_2: require('prop-types').string.isRequired
     }).isRequired
   }).isRequired,
   should_error_if_provided: function should_error_if_provided(props, propName, componentName) {
-    if (props[propName] != null) return new Error(\'Invalid prop \`\' + propName + \'\` of value \`\' + value + \'\` passed to \`\' + componentName + \'\`. Expected undefined or null.\');
+    if (props[propName] != null) return new Error('Invalid prop \`' + propName + '\` of value \`' + value + '\` passed to \`' + componentName + '\`. Expected undefined or null.');
   }
 };"
 `;

--- a/src/__tests__/__snapshots__/stateless-without-jsx-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-without-jsx-test.js.snap
@@ -1,18 +1,20 @@
-exports[`test stateless-without-jsx 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`stateless-without-jsx 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var React = require(\'react\');
+var React = require('react');
 
 var Foo = function Foo(props) {
-  React.createElement(\'div\', null, props.x);
+  React.createElement('div', null, props.x);
 };
 
 Foo.propTypes = {
-  x: require(\'prop-types\').number
+  x: require('prop-types').number
 };
 exports.default = Foo;"
 `;

--- a/src/__tests__/__snapshots__/suppress-test.js.snap
+++ b/src/__tests__/__snapshots__/suppress-test.js.snap
@@ -1,19 +1,21 @@
-exports[`test suppress 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-\'no babel-plugin-flow-react-proptypes\';
+exports[`suppress 1`] = `
+"'use strict';
 
-Object.defineProperty(exports, \"__esModule\", {
+'no babel-plugin-flow-react-proptypes';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
 var Foo = function (_React$Component) {
   _inherits(Foo, _React$Component);

--- a/src/__tests__/__snapshots__/test-issue-66.js.snap
+++ b/src/__tests__/__snapshots__/test-issue-66.js.snap
@@ -1,7 +1,9 @@
-exports[`test issue 66 1`] = `
-"\"use strict\";
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`issue 66 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
@@ -9,6 +11,6 @@ exports.default = function (url, options) {
   var Html = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : DefaultHtml;
 
 
-  return React.createElement(\"div\", null);
+  return React.createElement(\\"div\\", null);
 };"
 `;

--- a/src/__tests__/__snapshots__/top-level-import-test.js.snap
+++ b/src/__tests__/__snapshots__/top-level-import-test.js.snap
@@ -1,25 +1,27 @@
-exports[`test basic 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`basic 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\"value\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require(\'react\');
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var babelPluginFlowReactPropTypes_proptype_Data = require(\'types\').babelPluginFlowReactPropTypes_proptype_Data || require(\'prop-types\').any;
+var babelPluginFlowReactPropTypes_proptype_Data = require('types').babelPluginFlowReactPropTypes_proptype_Data || require('prop-types').any;
 
 var Test = function (_Component) {
   _inherits(Test, _Component);
@@ -31,13 +33,13 @@ var Test = function (_Component) {
   }
 
   _createClass(Test, [{
-    key: \'render\',
+    key: 'render',
     value: function render() {
       return _react2.default.createElement(
-        \'div\',
+        'div',
         null,
         this.props.id,
-        \' \',
+        ' ',
         this.props.title
       );
     }
@@ -46,6 +48,6 @@ var Test = function (_Component) {
   return Test;
 }(_react.Component);
 
-Test.propTypes = babelPluginFlowReactPropTypes_proptype_Data === require(\'prop-types\').any ? {} : babelPluginFlowReactPropTypes_proptype_Data;
+Test.propTypes = babelPluginFlowReactPropTypes_proptype_Data === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_Data;
 exports.default = Test;"
 `;

--- a/src/__tests__/__snapshots__/tupletype-test.js.snap
+++ b/src/__tests__/__snapshots__/tupletype-test.js.snap
@@ -1,18 +1,20 @@
-exports[`test tupletype 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`tupletype 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.default = Foo;
 
-var React = require(\'react\');
+var React = require('react');
 
 function Foo(props) {
-  React.createElement(\'div\', null);
+  React.createElement('div', null);
 }
 Foo.propTypes = {
-  an_optional_string: require(\'prop-types\').string,
-  tupletype: require(\'prop-types\').arrayOf(require(\'prop-types\').any).isRequired
+  an_optional_string: require('prop-types').string,
+  tupletype: require('prop-types').arrayOf(require('prop-types').any).isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/typeof-test.js.snap
+++ b/src/__tests__/__snapshots__/typeof-test.js.snap
@@ -1,14 +1,16 @@
-exports[`test typeof 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typeof 1`] = `
+"'use strict';
 
 var ActionTypes = {
-  JUMP_TO: \'react-native/NavigationExperimental/tabs-jumpTo\'
+  JUMP_TO: 'react-native/NavigationExperimental/tabs-jumpTo'
 };
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_JumpToAction\', {
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_JumpToAction', {
   value: {
-    type: require(\'prop-types\').any.isRequired,
-    index: require(\'prop-types\').number.isRequired
+    type: require('prop-types').any.isRequired,
+    index: require('prop-types').number.isRequired
   }
 });"
 `;

--- a/src/__tests__/__snapshots__/union-types-and-contants.js.snap
+++ b/src/__tests__/__snapshots__/union-types-and-contants.js.snap
@@ -1,20 +1,22 @@
-exports[`test union-types-and-constants 1`] = `
-"\'use strict\';
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-Object.defineProperty(exports, \"__esModule\", {
+exports[`union-types-and-constants 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\"this hasn\'t been initialised - super() hasn\'t been called\"); } return call && (typeof call === \"object\" || typeof call === \"function\") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \"function\" && superClass !== null) { throw new TypeError(\"Super expression must either be null or a function, not \" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var React = require(\'react\');
+var React = require('react');
 
-if (typeof exports !== \'undefined\') Object.defineProperty(exports, \'babelPluginFlowReactPropTypes_proptype_U\', {
-  value: require(\'prop-types\').oneOfType([require(\'prop-types\').oneOf([\'foo\']), require(\'prop-types\').oneOf([\'bar\']), require(\'prop-types\').number])
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
+  value: require('prop-types').oneOfType([require('prop-types').oneOf(['foo']), require('prop-types').oneOf(['bar']), require('prop-types').number])
 });
 
 var Foo = function (_React$Component) {
@@ -30,7 +32,7 @@ var Foo = function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = {
-  id: require(\'prop-types\').oneOfType([require(\'prop-types\').oneOf([\'foo\']), require(\'prop-types\').oneOf([\'bar\']), require(\'prop-types\').number]).isRequired
+  id: require('prop-types').oneOfType([require('prop-types').oneOf(['foo']), require('prop-types').oneOf(['bar']), require('prop-types').number]).isRequired
 };
 exports.default = C;"
 `;

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -24,7 +24,7 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
   }
   else if (node.type === 'FunctionTypeAnnotation') resultPropType = {type: 'func'};
   else if (node.type === 'AnyTypeAnnotation') resultPropType = {type: 'any'};
-  else if (node.type === 'ExistentialTypeParam') resultPropType = {type: 'any'};
+  else if (node.type === 'ExistsTypeAnnotation') resultPropType = {type: 'any'};
   else if (node.type === 'MixedTypeAnnotation') resultPropType = {type: 'any'};
   else if (node.type === 'TypeofTypeAnnotation') resultPropType = {type: 'any'};
   else if (node.type === 'NumberTypeAnnotation') resultPropType = {type: 'number'};
@@ -132,7 +132,7 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
   }
   else if (node.type in {
     'StringLiteralTypeAnnotation': 0,
-    'NumericLiteralTypeAnnotation': 0,
+    'NumberLiteralTypeAnnotation': 0,
     'BooleanLiteralTypeAnnotation': 0,
     'NullLiteralTypeAnnotation': 0,
   }) {

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -196,7 +196,7 @@ function processQualifiedTypeIdentifierIntoMemberExpression(qualifiedTypeIdentif
 
   const memberExpression = t.memberExpression(objectAST, propertyAST);
 
-  return t.conditionalExpression(makeNullCheckAST(memberExpression), t.objectExpression([]), memberExpression)
+  return t.conditionalExpression(makeNullCheckAST(memberExpression), t.objectExpression([]), memberExpression);
 
 }
 


### PR DESCRIPTION
This is an early update PR that might be best to merge this against a `next` branch instead of master; let me know if you want me to resubmit against a different branch.

- Update for babel 7 ([see upgrade notes](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7-for-tool-authors))
- Update all dependencies
- Update jest snapshots - manually checked differences on every file - looks good to me though I'm just one human
- **not for production** - used `yarn --flat` which adds `resolutions` to the `package.json` to force packages up to 7.x for testing code changes.  Proper resolutions of packages will therefore only work with yarn at this time.  This section can be removed once the dependencies and transitive dependencies are converted.  Problematic (most) was transitive `babel-plugin-transform-es2015-arrow-functions` through `babel-jest` through `jest-runtime` if I recall correctly. 
- tests pass locally, though I expect travis to fail based on ^^^ and the fact it uses npm for resolution

