### PR TITLE
Implement object type spread

### DIFF
--- a/src/__tests__/__snapshots__/object-type-spread-exact.js.snap
+++ b/src/__tests__/__snapshots__/object-type-spread-exact.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`object-type-spread-exact 1`] = `
+"\\"use strict\\";
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var MyComponent = function (_React$Component) {
+    _inherits(MyComponent, _React$Component);
+
+    function MyComponent() {
+        _classCallCheck(this, MyComponent);
+
+        return _possibleConstructorReturn(this, (MyComponent.__proto__ || Object.getPrototypeOf(MyComponent)).apply(this, arguments));
+    }
+
+    return MyComponent;
+}(React.Component);
+
+MyComponent.propTypes = {
+    bar: require(\\"prop-types\\").string.isRequired,
+    foo: require(\\"prop-types\\").string.isRequired
+};"
+`;

--- a/src/__tests__/__snapshots__/object-type-spread-simple.js.snap
+++ b/src/__tests__/__snapshots__/object-type-spread-simple.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`object-type-spread-simple 1`] = `
+"\\"use strict\\";
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var MyComponent = function (_React$Component) {
+    _inherits(MyComponent, _React$Component);
+
+    function MyComponent() {
+        _classCallCheck(this, MyComponent);
+
+        return _possibleConstructorReturn(this, (MyComponent.__proto__ || Object.getPrototypeOf(MyComponent)).apply(this, arguments));
+    }
+
+    return MyComponent;
+}(React.Component);
+
+MyComponent.propTypes = {
+    bar: require(\\"prop-types\\").string.isRequired,
+    foo: require(\\"prop-types\\").string
+};"
+`;

--- a/src/__tests__/object-type-spread-exact.js
+++ b/src/__tests__/object-type-spread-exact.js
@@ -5,8 +5,8 @@ type A = {
 } 
 
 type Props = {
-    ...$Exact<A>,
-    bar: string
+    bar: string,
+    ...$Exact<A>
 };
 
 class MyComponent extends React.Component {

--- a/src/__tests__/object-type-spread-exact.js
+++ b/src/__tests__/object-type-spread-exact.js
@@ -1,0 +1,24 @@
+const babel = require('babel-core');
+const content = `
+type A = {
+    foo: string
+} 
+
+type Props = {
+    ...$Exact<A>,
+    bar: string
+};
+
+class MyComponent extends React.Component {
+    props: Props;
+}
+`;
+
+it('object-type-spread-exact', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/object-type-spread-simple.js
+++ b/src/__tests__/object-type-spread-simple.js
@@ -1,0 +1,24 @@
+const babel = require('babel-core');
+const content = `
+type A = {
+    foo: string
+} 
+
+type Props = {
+    ...A,
+    bar: string
+};
+
+class MyComponent extends React.Component {
+    props: Props;
+}
+`;
+
+it('object-type-spread-simple', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/object-type-spread-simple.js
+++ b/src/__tests__/object-type-spread-simple.js
@@ -5,8 +5,8 @@ type A = {
 } 
 
 type Props = {
-    ...A,
-    bar: string
+    bar: string,
+    ...A
 };
 
 class MyComponent extends React.Component {

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -40,17 +40,17 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     return {key, value};
   }
   else if (node.type === 'ObjectTypeSpreadProperty') {
-    const exact = isExact(node.argument)
-    let subnode
+    const exact = isExact(node.argument);
+    let subnode;
     if(exact) {
-      subnode = node.argument.typeParameters.params[0]
+      subnode = node.argument.typeParameters.params[0];
     }
     else {
-      subnode = node.argument
+      subnode = node.argument;
     }
     
     const spreadShape = convertToPropTypes(subnode, importedTypes, internalTypes);
-    const properties = spreadShape.properties
+    const properties = spreadShape.properties;
 
     // Unless or until the strange default behavior changes in flow (https://github.com/facebook/flow/issues/3214)
     // every property from spread becomes optional unless it uses `...$Exact<T>`

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -40,7 +40,16 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     return {key, value};
   }
   else if (node.type === 'ObjectTypeSpreadProperty') {
-    const spreadShape = convertToPropTypes(node.argument.typeParameters.params[0], importedTypes, internalTypes);
+    const exact = isExact(node.argument)
+    let subnode
+    if(exact) {
+      subnode = node.argument.typeParameters.params[0]
+    }
+    else {
+      subnode = node.argument
+    }
+    
+    const spreadShape = convertToPropTypes(subnode, importedTypes, internalTypes);
     const properties = spreadShape.properties
 
     // Unless or until the strange default behavior changes in flow (https://github.com/facebook/flow/issues/3214)
@@ -48,12 +57,10 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     
     // @see also explanation of behavior - https://github.com/facebook/flow/issues/3534#issuecomment-287580240
     // @returns flattened properties from shape
-    if(isExact(node.argument)) {
-      return properties; 
-    }
-    else {
+    if(!exact) {
       properties.forEach((prop) => prop.value.isRequired = false);
     }
+    return properties;
   }
   else if (node.type === 'FunctionTypeAnnotation') resultPropType = {type: 'func'};
   else if (node.type === 'AnyTypeAnnotation') resultPropType = {type: 'any'};

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -14,7 +14,12 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
       //  ObjectTypeSpreadProperty - Array<{key, value}>
       const result = convertToPropTypes(subnode, importedTypes, internalTypes)
 
-      properties.push(result)
+      if (Array.isArray(result)){
+        result.forEach((prop) => properties.push(prop))
+      }
+      else {
+        properties.push(result);
+      }
     });
 
     // return a shape
@@ -33,6 +38,11 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     }
 
     return {key, value};
+  }
+  else if (node.type === 'ObjectTypeSpreadProperty') {
+    // FIXME: $Exact vs inexact semantics - MUST DO! - https://github.com/facebook/flow/issues/3534#issuecomment-287580240
+    const spreadShape = convertToPropTypes(node.argument.typeParameters.params[0], importedTypes, internalTypes);
+    return spreadShape.properties; // return flattened properties from shape
   }
   else if (node.type === 'FunctionTypeAnnotation') resultPropType = {type: 'func'};
   else if (node.type === 'AnyTypeAnnotation') resultPropType = {type: 'any'};

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,10 @@ export const $debug = () => {};
 
 export const PLUGIN_NAME = 'babel-plugin-flow-react-proptypes';
 
+export function isExact(node) {
+  return node.id.name === '$Exact';
+}
+
 export function makeLiteral(value) {
   if (typeof value === 'string') return t.stringLiteral(value);
   else if (typeof value === 'number') return t.numericLiteral(value);


### PR DESCRIPTION
Closes #103 

Object type spread was introduced in [Flow 0.42.0](https://github.com/facebook/flow/releases/tag/v0.42.0)

_Documentation_ is not yet published, but the [behavior is documented here](https://github.com/facebook/flow/issues/3534#issuecomment-287580240) and this is referenced in the implementation, as use without `$Exact` is odd - it makes all prop values from the spread optional. 

I have mirrored flow behavior, though I expect the [default behavior may change](https://github.com/facebook/flow/issues/3214).  This too is commented in code so we have some sanity to check and change it in the future.

This is on the `babel-7` branch, but it's quite possible this change could be cherry picked back to the `master`.