### PR TITLE
Prevent export duplication

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "env": {
+    "development": {
+      "sourceMaps": "inline"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^4.0.0",
     "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.4",
+    "jest-environment-node-debug": "^2.0.0",
     "prettier": "^1.4.4",
     "react": "^15.5.4",
     "react-test-renderer": "^15.5.4"

--- a/src/__tests__/__snapshots__/basic-test.js.snap
+++ b/src/__tests__/__snapshots__/basic-test.js.snap
@@ -15,10 +15,11 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_Qux = {
+  baz: require('prop-types').oneOf(['literal']).isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Qux', {
-  value: {
-    baz: require('prop-types').oneOf(['literal']).isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_Qux,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/export-exact-object-type.js.snap
+++ b/src/__tests__/__snapshots__/export-exact-object-type.js.snap
@@ -9,10 +9,11 @@ var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+var babelPluginFlowReactPropTypes_proptype_VendorProps = {
+  test: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_VendorProps', {
-  value: {
-    test: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_VendorProps,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -15,17 +15,19 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+  bar: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
-  value: {
-    bar: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });
+var babelPluginFlowReactPropTypes_proptype_U = {
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
-  value: {
-    bar: require('prop-types').string.isRequired,
-    foo: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_U,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/export-intersection-type.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-type.js.snap
@@ -15,11 +15,12 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_V = {
+  foo: require('prop-types').string.isRequired,
+  bar: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_V', {
-  value: {
-    foo: require('prop-types').string.isRequired,
-    bar: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_V,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
+++ b/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
@@ -3,8 +3,10 @@
 exports[`export-non-object-types 1`] = `
 "\\"use strict\\";
 
+var babelPluginFlowReactPropTypes_proptype_Answer = require(\\"prop-types\\").oneOf([\\"Yes\\", \\"No\\"]);
+
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_Answer\\", {
-  value: require(\\"prop-types\\").oneOf([\\"Yes\\", \\"No\\"]),
+  value: babelPluginFlowReactPropTypes_proptype_Answer,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-object-test.js.snap
+++ b/src/__tests__/__snapshots__/export-object-test.js.snap
@@ -3,10 +3,11 @@
 exports[`export-object 1`] = `
 "'use strict';
 
+var babelPluginFlowReactPropTypes_proptype_Foo = {
+  a_string: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Foo', {
-  value: {
-    a_string: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_Foo,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/export-string-type.js.snap
+++ b/src/__tests__/__snapshots__/export-string-type.js.snap
@@ -3,12 +3,17 @@
 exports[`export-intersection-type 1`] = `
 "\\"use strict\\";
 
+var babelPluginFlowReactPropTypes_proptype_T = require(\\"prop-types\\").string;
+
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_T\\", {
-  value: require(\\"prop-types\\").string,
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });
+
+var babelPluginFlowReactPropTypes_proptype_TOptional = require(\\"prop-types\\").string;
+
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_TOptional\\", {
-  value: require(\\"prop-types\\").string,
+  value: babelPluginFlowReactPropTypes_proptype_TOptional,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
+++ b/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
@@ -13,12 +13,13 @@ var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+  f: require('prop-types').func.isRequired,
+  i: require('prop-types').number.isRequired,
+  x: require('prop-types').oneOf(['foo', 'baz']).isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
-  value: {
-    f: require('prop-types').func.isRequired,
-    i: require('prop-types').number.isRequired,
-    x: require('prop-types').oneOf(['foo', 'baz']).isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });
 
@@ -29,10 +30,6 @@ var C = function C(_ref) {
   _react2.default.createElement('div', null);
 };
 
-C.propTypes = {
-  f: require('prop-types').func.isRequired,
-  i: require('prop-types').number.isRequired,
-  x: require('prop-types').oneOf(['foo', 'baz']).isRequired
-};
+C.propTypes = babelPluginFlowReactPropTypes_proptype_T;
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/export-union-type.js.snap
+++ b/src/__tests__/__snapshots__/export-union-type.js.snap
@@ -3,8 +3,10 @@
 exports[`export-union-type 1`] = `
 "\\"use strict\\";
 
+var babelPluginFlowReactPropTypes_proptype_A = require(\\"prop-types\\").oneOf([\\"option1\\", \\"option2\\"]);
+
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_A\\", {
-  value: require(\\"prop-types\\").oneOf([\\"option1\\", \\"option2\\"]),
+  value: babelPluginFlowReactPropTypes_proptype_A,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/import-and-loops-test.js.snap
+++ b/src/__tests__/__snapshots__/import-and-loops-test.js.snap
@@ -15,11 +15,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var babelPluginFlowReactPropTypes_proptype_ExternalType = require('../types').babelPluginFlowReactPropTypes_proptype_ExternalType || require('prop-types').any;
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+    flag: require('prop-types').bool.isRequired,
+    list: require('prop-types').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
-    value: {
-        flag: require('prop-types').bool.isRequired,
-        list: require('prop-types').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
-    },
+    value: babelPluginFlowReactPropTypes_proptype_T,
     configurable: true
 });
 
@@ -41,9 +42,6 @@ var C = function C(_ref) {
     );
 };
 
-C.propTypes = {
-    flag: require('prop-types').bool.isRequired,
-    list: require('prop-types').arrayOf(typeof babelPluginFlowReactPropTypes_proptype_ExternalType === 'function' ? babelPluginFlowReactPropTypes_proptype_ExternalType : require('prop-types').shape(babelPluginFlowReactPropTypes_proptype_ExternalType)).isRequired
-};
+C.propTypes = babelPluginFlowReactPropTypes_proptype_T;
 exports.default = C;"
 `;

--- a/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
+++ b/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
@@ -11,12 +11,14 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var babelPluginFlowReactPropTypes_proptype_Fact = typeof (Foo.Bar == null ? {} : Foo.Bar) === 'function' ? require('prop-types').instanceOf(Foo.Bar == null ? {} : Foo.Bar) : require('prop-types').any;
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Fact', {
-  value: typeof (Foo.Bar == null ? {} : Foo.Bar) === 'function' ? require('prop-types').instanceOf(Foo.Bar == null ? {} : Foo.Bar) : require('prop-types').any,
+  value: babelPluginFlowReactPropTypes_proptype_Fact,
   configurable: true
 });
+var babelPluginFlowReactPropTypes_proptype_FactMap = typeof (Foo.Map == null ? {} : Foo.Map) === 'function' ? require('prop-types').instanceOf(Foo.Map == null ? {} : Foo.Map) : require('prop-types').any;
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_FactMap', {
-  value: typeof (Foo.Map == null ? {} : Foo.Map) === 'function' ? require('prop-types').instanceOf(Foo.Map == null ? {} : Foo.Map) : require('prop-types').any,
+  value: babelPluginFlowReactPropTypes_proptype_FactMap,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-complex-example.js.snap
@@ -19,27 +19,30 @@ var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").ba
 
 var babelPluginFlowReactPropTypes_proptype_DefaultType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_DefaultType || require(\\"prop-types\\").any;
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+  foo: require(\\"prop-types\\").string.isRequired
+};
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_T\\", {
-  value: {
-    foo: require(\\"prop-types\\").string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });
+var babelPluginFlowReactPropTypes_proptype_U = {
+  bar: require(\\"prop-types\\").number.isRequired
+};
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_U\\", {
-  value: {
-    bar: require(\\"prop-types\\").number.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_U,
   configurable: true
+});
+var babelPluginFlowReactPropTypes_proptype_X = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+  a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired : babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
+  b: require(\\"prop-types\\").string.isRequired
+}, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
+  bar: require(\\"prop-types\\").number.isRequired
+}, {
+  foo: require(\\"prop-types\\").string.isRequired
 });
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
-  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-    a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired : babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
-    b: require(\\"prop-types\\").string.isRequired
-  }, babelPluginFlowReactPropTypes_proptype_DefaultType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_DefaultType, {
-    bar: require(\\"prop-types\\").number.isRequired
-  }, {
-    foo: require(\\"prop-types\\").string.isRequired
-  }),
+  value: babelPluginFlowReactPropTypes_proptype_X,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-export-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-export-test.js.snap
@@ -17,10 +17,11 @@ var React = require('react');
 
 var babelPluginFlowReactPropTypes_proptype_T = require('./T').babelPluginFlowReactPropTypes_proptype_T || require('prop-types').any;
 
+var babelPluginFlowReactPropTypes_proptype_U = Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
+  foo: require('prop-types').string.isRequired
+});
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
-  value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_T === require('prop-types').any ? {} : babelPluginFlowReactPropTypes_proptype_T, {
-    foo: require('prop-types').string.isRequired
-  }),
+  value: babelPluginFlowReactPropTypes_proptype_U,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
@@ -11,10 +11,11 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
+var babelPluginFlowReactPropTypes_proptype_ExportedType = {
+  bar: require(\\"prop-types\\").number.isRequired
+};
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
-  value: {
-    bar: require(\\"prop-types\\").number.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_ExportedType,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
@@ -9,10 +9,11 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var babelPluginFlowReactPropTypes_proptype_ExportedType = {
+  bar: require(\\"prop-types\\").number.isRequired
+};
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
-  value: {
-    bar: require(\\"prop-types\\").number.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_ExportedType,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
@@ -17,10 +17,11 @@ var React = require('react');
 
 var babelPluginFlowReactPropTypes_proptype_NamedType = require(\\"./types\\").babelPluginFlowReactPropTypes_proptype_NamedType || require(\\"prop-types\\").any;
 
+var babelPluginFlowReactPropTypes_proptype_X = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
+   a: require(\\"prop-types\\").string.isRequired
+});
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
-   value: Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
-      a: require(\\"prop-types\\").string.isRequired
-   }),
+   value: babelPluginFlowReactPropTypes_proptype_X,
    configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
@@ -15,11 +15,12 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_U = {
+  bar: require('prop-types').string.isRequired,
+  foo: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
-  value: {
-    bar: require('prop-types').string.isRequired,
-    foo: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_U,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -15,10 +15,11 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+  bar: require('prop-types').string.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
-  value: {
-    bar: require('prop-types').string.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/string-literal-property.js.snap
+++ b/src/__tests__/__snapshots__/string-literal-property.js.snap
@@ -3,11 +3,12 @@
 exports[`string-literal-property 1`] = `
 "'use strict';
 
+var babelPluginFlowReactPropTypes_proptype_T = {
+  \\"read-only\\": require('prop-types').oneOf([true]).isRequired,
+  regular: require('prop-types').oneOf([true]).isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
-  value: {
-    \\"read-only\\": require('prop-types').oneOf([true]).isRequired,
-    regular: require('prop-types').oneOf([true]).isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_T,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/typeof-test.js.snap
+++ b/src/__tests__/__snapshots__/typeof-test.js.snap
@@ -7,11 +7,12 @@ var ActionTypes = {
   JUMP_TO: 'react-native/NavigationExperimental/tabs-jumpTo'
 };
 
+var babelPluginFlowReactPropTypes_proptype_JumpToAction = {
+  type: require('prop-types').any.isRequired,
+  index: require('prop-types').number.isRequired
+};
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_JumpToAction', {
-  value: {
-    type: require('prop-types').any.isRequired,
-    index: require('prop-types').number.isRequired
-  },
+  value: babelPluginFlowReactPropTypes_proptype_JumpToAction,
   configurable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/union-objects-exact.js.snap
+++ b/src/__tests__/__snapshots__/union-objects-exact.js.snap
@@ -11,30 +11,31 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
-if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_ExactFooProps', {
-  value: {
-    someprop: require('prop-types').oneOfType([require('prop-types').shape({
-      a: require('prop-types').string.isRequired
-    }), require('prop-types').shape({
-      b: require('prop-types').number.isRequired,
-      __exact__: function __exact__(values, prop, displayName) {
-        var props = {
-          b: true
-        };
-        var extra = [];
+var babelPluginFlowReactPropTypes_proptype_ExactFooProps = {
+  someprop: require('prop-types').oneOfType([require('prop-types').shape({
+    a: require('prop-types').string.isRequired
+  }), require('prop-types').shape({
+    b: require('prop-types').number.isRequired,
+    __exact__: function __exact__(values, prop, displayName) {
+      var props = {
+        b: true
+      };
+      var extra = [];
 
-        for (var k in values) {
-          if (values.hasOwnProperty(k) && !props.hasOwnProperty(k)) {
-            extra.push(k);
-          }
-        }
-
-        if (extra.length > 0) {
-          return new Error('Invalid additional prop(s) ' + JSON.stringify(extra));
+      for (var k in values) {
+        if (values.hasOwnProperty(k) && !props.hasOwnProperty(k)) {
+          extra.push(k);
         }
       }
-    })]).isRequired
-  },
+
+      if (extra.length > 0) {
+        return new Error('Invalid additional prop(s) ' + JSON.stringify(extra));
+      }
+    }
+  })]).isRequired
+};
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_ExactFooProps', {
+  value: babelPluginFlowReactPropTypes_proptype_ExactFooProps,
   configurable: true
 });
 

--- a/src/__tests__/__snapshots__/union-types-and-contants.js.snap
+++ b/src/__tests__/__snapshots__/union-types-and-contants.js.snap
@@ -15,8 +15,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 
 var React = require('react');
 
+var babelPluginFlowReactPropTypes_proptype_U = require('prop-types').oneOfType([require('prop-types').oneOf(['foo']), require('prop-types').oneOf(['bar']), require('prop-types').number]);
+
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
-  value: require('prop-types').oneOfType([require('prop-types').oneOf(['foo']), require('prop-types').oneOf(['bar']), require('prop-types').number]),
+  value: babelPluginFlowReactPropTypes_proptype_U,
   configurable: true
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -253,7 +253,7 @@ module.exports = function flowReactPropTypes(babel) {
             t.identifier('exports'),
             t.stringLiteral(getExportNameForType(name)),
             t.objectExpression([
-              t.objectProperty(t.identifier('value'), propTypesAst),
+              t.objectProperty(t.identifier('value'), propTypesAst), // FIXME: this should be the ref to the var declaration created in makePropTypesAstForPropTypesAssignment
               t.objectProperty(t.identifier('configurable'), t.booleanLiteral(true)),
             ]),
           ]

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,9 @@ module.exports = function flowReactPropTypes(babel) {
     if (!typeAnnotation) {
       $debug('Found stateless component without type definition');
     } else {
-      propsOrVar = exportedTypes[typeAnnotation.id.name] || getPropsForTypeAnnotation(typeAnnotation);
+      propsOrVar = typeAnnotation.id && exportedTypes[typeAnnotation.id.name] ?
+        exportedTypes[typeAnnotation.id.name] :
+        getPropsForTypeAnnotation(typeAnnotation);
     }
 
     if (propsOrVar) {

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ module.exports = function flowReactPropTypes(babel) {
       throw new Error(`Did not find type annotation for ${name}`);
     }
 
-    let attachPropTypesAST
+    let attachPropTypesAST;
     // if type was exported, use the declared variable
     if (typeof propsOrVar === 'string'){
       attachPropTypesAST = t.expressionStatement(
@@ -140,10 +140,11 @@ module.exports = function flowReactPropTypes(babel) {
       && firstParam.typeAnnotation
       && firstParam.typeAnnotation.typeAnnotation;
 
-    let propsOrVar = null
+    let propsOrVar = null;
     if (!typeAnnotation) {
       $debug('Found stateless component without type definition');
-    } else {
+    }
+    else {
       propsOrVar = typeAnnotation.id && exportedTypes[typeAnnotation.id.name] ?
         exportedTypes[typeAnnotation.id.name] :
         getPropsForTypeAnnotation(typeAnnotation);

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ let internalTypes = {};
 
 // maps between type alias to import alias
 let importedTypes = {};
+
+let exportedTypes = {};
 let suppress = false;
 const SUPPRESS_STRING = 'no babel-plugin-flow-react-proptypes';
 
@@ -45,21 +47,6 @@ const getPropsForTypeAnnotation = typeAnnotation => {
   return props;
 };
 
-const getFunctionalComponentTypeProps = path => {
-  // Check if this looks like a stateless react component with PropType reference:
-  const firstParam = path.node.params[0];
-  const typeAnnotation = firstParam
-    && firstParam.typeAnnotation
-    && firstParam.typeAnnotation.typeAnnotation;
-
-  if (!typeAnnotation) {
-    $debug('Found stateless component without type definition');
-    return;
-  }
-
-  return getPropsForTypeAnnotation(typeAnnotation);
-};
-
 module.exports = function flowReactPropTypes(babel) {
   const t = babel.types;
 
@@ -85,9 +72,9 @@ module.exports = function flowReactPropTypes(babel) {
      *
      *
      * @param path
-     * @param props
+     * @param propsOrVar - props or exported props variable reference
      */
-  const annotate = (path, props) => {
+  const annotate = (path, propsOrVar) => {
     let name;
     let targetPath;
 
@@ -102,21 +89,35 @@ module.exports = function flowReactPropTypes(babel) {
       targetPath = ['Program', 'BlockStatement'].indexOf(path.parent.type) >= 0 ? path : path.parentPath;
     }
 
-    if (!props) {
+    if (!propsOrVar) {
       throw new Error(`Did not find type annotation for ${name}`);
     }
 
-    const propTypesAST = makePropTypesAstForPropTypesAssignment(props);
-    if (propTypesAST == null) {
-      return;
+    let attachPropTypesAST
+    // if type was exported, use the declared variable
+    if (typeof propsOrVar === 'string'){
+      attachPropTypesAST = t.expressionStatement(
+        t.assignmentExpression(
+          '=',
+          t.memberExpression(t.identifier(name), t.identifier('propTypes')),
+          t.identifier(propsOrVar)
+        )
+      );
     }
-    const attachPropTypesAST = t.expressionStatement(
-      t.assignmentExpression(
-        '=',
-        t.memberExpression(t.identifier(name), t.identifier('propTypes')),
-        propTypesAST
-      )
-    );
+    // type was not exported, generate
+    else {
+      const propTypesAST = makePropTypesAstForPropTypesAssignment(propsOrVar);
+      if (propTypesAST == null) {
+        return;
+      }
+      attachPropTypesAST = t.expressionStatement(
+        t.assignmentExpression(
+          '=',
+          t.memberExpression(t.identifier(name), t.identifier('propTypes')),
+          propTypesAST
+        )
+      );
+    }
     targetPath.insertAfter(attachPropTypesAST);
   };
 
@@ -132,9 +133,22 @@ module.exports = function flowReactPropTypes(babel) {
     if (!isFunctionalReactComponent(path)) {
       return;
     }
-    const props = getFunctionalComponentTypeProps(path);
-    if (props) {
-      annotate(path, props);
+
+    // Check if this looks like a stateless react component with PropType reference:
+    const firstParam = path.node.params[0];
+    const typeAnnotation = firstParam
+      && firstParam.typeAnnotation
+      && firstParam.typeAnnotation.typeAnnotation;
+
+    let propsOrVar = null
+    if (!typeAnnotation) {
+      $debug('Found stateless component without type definition');
+    } else {
+      propsOrVar = exportedTypes[typeAnnotation.id.name] || getPropsForTypeAnnotation(typeAnnotation);
+    }
+
+    if (propsOrVar) {
+      annotate(path, propsOrVar);
     }
   };
 
@@ -143,6 +157,7 @@ module.exports = function flowReactPropTypes(babel) {
       Program(path, {opts}) {
         internalTypes = {};
         importedTypes = {};
+        exportedTypes = {};
         suppress = false;
         const directives = path.node.directives;
         if(directives && directives.length)  {
@@ -247,13 +262,28 @@ module.exports = function flowReactPropTypes(babel) {
 
         const propTypesAst = makePropTypesAstForExport(propTypes);
 
+        // create a variable for reuse
+        const exportedName = getExportNameForType(name);
+        exportedTypes[name] = exportedName;
+        const variableDeclarationAst = t.variableDeclaration(
+          'var',
+          [
+            t.variableDeclarator(
+              t.identifier(exportedName),
+              propTypesAst
+            )
+          ]
+        );
+        path.insertBefore(variableDeclarationAst);
+
+        // add the variable to the exports
         const exportAst = t.expressionStatement(t.callExpression(
           t.memberExpression(t.identifier('Object'), t.identifier('defineProperty')),
           [
             t.identifier('exports'),
             t.stringLiteral(getExportNameForType(name)),
             t.objectExpression([
-              t.objectProperty(t.identifier('value'), propTypesAst), // FIXME: this should be the ref to the var declaration created in makePropTypesAstForPropTypesAssignment
+              t.objectProperty(t.identifier('value'), t.identifier(exportedName)),
               t.objectProperty(t.identifier('configurable'), t.booleanLiteral(true)),
             ]),
           ]

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -51,7 +51,6 @@ export function makePropTypesAstForPropTypesAssignment(propTypeData) {
   else if (propTypeData.type === 'raw') {
     return makeObjectAstForRaw(propTypeData);
   }
-  // FIXME - this needs to create a variable with the output or return the existing one.
 };
 
 

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -51,6 +51,7 @@ export function makePropTypesAstForPropTypesAssignment(propTypeData) {
   else if (propTypeData.type === 'raw') {
     return makeObjectAstForRaw(propTypeData);
   }
+  // FIXME - this needs to create a variable with the output or return the existing one.
 };
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,6 +2059,10 @@ jest-environment-jsdom@^20.0.3:
     jest-util "^20.0.3"
     jsdom "^9.12.0"
 
+jest-environment-node-debug@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node-debug/-/jest-environment-node-debug-2.0.0.tgz#5ef098942fec1b6af5ee4841f4f8a2ff419562f9"
+
 jest-environment-node@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.3.tgz#d488bc4612af2c246e986e8ae7671a099163d403"


### PR DESCRIPTION
Solves #120 

As it were, if you added `export` to `type Props` it would generate double the code, which we found could become sizable when using with props heavy components.

This change will instead declare a var and reuse such as:

```javascript
var babelPluginFlowReactPropTypes_proptype_Props = { /* ... */ }; 
TextField.propTypes = babelPluginFlowReactPropTypes_proptype_Props;
if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Props',   
    value: babelPluginFlowReactPropTypes_proptype_Props,
    configurable: true
  });
```