### PR TITLE
Feature: add optional `omitRuntimeTypeExport` to optimize production bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,28 @@ If you already have other plugins in plugins section. It is important to place
 
 If you're using the 'react' or 'flow' presets, you don't need to do anything special.
 
+## Minimizing production bundle size
+In production, omitting props and minimizing bundle size can be done with the additon of two things:
+1. Add the [transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) plugin
+2. Omit exported types to allow for dead code pruning
+
+There are cases where a library wishes to `export type` making types available in `*.js.flow` shadow files,
+but these may have no other purpose during runtime.  If you wish to omit the corresponding export of
+the generated flow types, using this option with the 
+[transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) 
+plugin will allow for the smallest production bundle size.
+
+An example snippet from a `.babelrc`:
+```json
+"production": {
+  "plugins": [
+    ["transform-react-remove-prop-types", {
+      "mode": "wrap",
+      "plugins": [
+        ["babel-plugin-flow-react-proptypes", {"omitRuntimeTypeExport": true}],
+        "babel-plugin-transform-flow-strip-types",
+      ]
+    }]
+  ]
+}
+```

--- a/src/__tests__/__snapshots__/omitRuntimeTypeExport-test.js.snap
+++ b/src/__tests__/__snapshots__/omitRuntimeTypeExport-test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`export-type-and-component 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var babelPluginFlowReactPropTypes_proptype_T = {
+  f: require('prop-types').func.isRequired,
+  i: require('prop-types').number.isRequired,
+  x: require('prop-types').oneOf(['foo', 'baz']).isRequired
+};
+
+
+var C = function C(_ref) {
+  var f = _ref.f;
+
+  _react2.default.createElement('div', null);
+};
+
+C.propTypes = babelPluginFlowReactPropTypes_proptype_T;
+exports.default = C;"
+`;

--- a/src/__tests__/omitRuntimeTypeExport-test.js
+++ b/src/__tests__/omitRuntimeTypeExport-test.js
@@ -1,0 +1,32 @@
+const babel = require('babel-core');
+const content = `
+// @flow
+
+import React from 'react';
+
+export type T = {
+  f: Function,
+  i: number,
+  x: 'foo' | 'baz',
+};
+
+const C = ({
+  f,
+}: T) => {
+   <div></div>
+};
+
+export default C;
+`;
+
+it('export-type-and-component', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: [
+      'syntax-flow',
+      [require('../'), {omitRuntimeTypeExport: true}]
+    ],
+  }).code;
+  expect(res).toMatchSnapshot();
+});


### PR DESCRIPTION
Solves #122 

I added a section to the readme that hopefully clarifies intent and use.

/cc @oliviertassinari 