### PR TITLE
make exported proptypes enumerable

### DIFF
--- a/src/__tests__/__snapshots__/basic-test.js.snap
+++ b/src/__tests__/__snapshots__/basic-test.js.snap
@@ -20,7 +20,8 @@ var babelPluginFlowReactPropTypes_proptype_Qux = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Qux', {
   value: babelPluginFlowReactPropTypes_proptype_Qux,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var babelPluginFlowReactPropTypes_proptype_SomeExternalType = require('./types').babelPluginFlowReactPropTypes_proptype_SomeExternalType || require('prop-types').any;

--- a/src/__tests__/__snapshots__/export-exact-object-type.js.snap
+++ b/src/__tests__/__snapshots__/export-exact-object-type.js.snap
@@ -14,6 +14,7 @@ var babelPluginFlowReactPropTypes_proptype_VendorProps = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_VendorProps', {
   value: babelPluginFlowReactPropTypes_proptype_VendorProps,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -20,7 +20,8 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 var babelPluginFlowReactPropTypes_proptype_U = {
   bar: require('prop-types').string.isRequired,
@@ -28,7 +29,8 @@ var babelPluginFlowReactPropTypes_proptype_U = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: babelPluginFlowReactPropTypes_proptype_U,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/export-intersection-type.js.snap
+++ b/src/__tests__/__snapshots__/export-intersection-type.js.snap
@@ -21,7 +21,8 @@ var babelPluginFlowReactPropTypes_proptype_V = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_V', {
   value: babelPluginFlowReactPropTypes_proptype_V,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
+++ b/src/__tests__/__snapshots__/export-non-object-types-test.js.snap
@@ -7,6 +7,7 @@ var babelPluginFlowReactPropTypes_proptype_Answer = require(\\"prop-types\\").on
 
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_Answer\\", {
   value: babelPluginFlowReactPropTypes_proptype_Answer,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-object-test.js.snap
+++ b/src/__tests__/__snapshots__/export-object-test.js.snap
@@ -8,7 +8,8 @@ var babelPluginFlowReactPropTypes_proptype_Foo = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Foo', {
   value: babelPluginFlowReactPropTypes_proptype_Foo,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 

--- a/src/__tests__/__snapshots__/export-string-type.js.snap
+++ b/src/__tests__/__snapshots__/export-string-type.js.snap
@@ -7,13 +7,15 @@ var babelPluginFlowReactPropTypes_proptype_T = require(\\"prop-types\\").string;
 
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_T\\", {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var babelPluginFlowReactPropTypes_proptype_TOptional = require(\\"prop-types\\").string;
 
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_TOptional\\", {
   value: babelPluginFlowReactPropTypes_proptype_TOptional,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
+++ b/src/__tests__/__snapshots__/export-type-and-component-test.js.snap
@@ -20,7 +20,8 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 

--- a/src/__tests__/__snapshots__/export-union-type.js.snap
+++ b/src/__tests__/__snapshots__/export-union-type.js.snap
@@ -7,6 +7,7 @@ var babelPluginFlowReactPropTypes_proptype_A = require(\\"prop-types\\").oneOf([
 
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_A\\", {
   value: babelPluginFlowReactPropTypes_proptype_A,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/import-and-loops-test.js.snap
+++ b/src/__tests__/__snapshots__/import-and-loops-test.js.snap
@@ -21,7 +21,8 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
     value: babelPluginFlowReactPropTypes_proptype_T,
-    configurable: true
+    configurable: true,
+    enumerable: true
 });
 
 

--- a/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
+++ b/src/__tests__/__snapshots__/instance-of-object-properties.js.snap
@@ -14,12 +14,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== \\"function
 var babelPluginFlowReactPropTypes_proptype_Fact = typeof (Foo.Bar == null ? {} : Foo.Bar) === 'function' ? require('prop-types').instanceOf(Foo.Bar == null ? {} : Foo.Bar) : require('prop-types').any;
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_Fact', {
   value: babelPluginFlowReactPropTypes_proptype_Fact,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 var babelPluginFlowReactPropTypes_proptype_FactMap = typeof (Foo.Map == null ? {} : Foo.Map) === 'function' ? require('prop-types').instanceOf(Foo.Map == null ? {} : Foo.Map) : require('prop-types').any;
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_FactMap', {
   value: babelPluginFlowReactPropTypes_proptype_FactMap,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var MyComponent = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-complex-example.js.snap
@@ -24,14 +24,16 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_T\\", {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 var babelPluginFlowReactPropTypes_proptype_U = {
   bar: require(\\"prop-types\\").number.isRequired
 };
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_U\\", {
   value: babelPluginFlowReactPropTypes_proptype_U,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 var babelPluginFlowReactPropTypes_proptype_X = Object.assign({}, babelPluginFlowReactPropTypes_proptype_NamedType === require(\\"prop-types\\").any ? {} : babelPluginFlowReactPropTypes_proptype_NamedType, {
   a: typeof babelPluginFlowReactPropTypes_proptype_NamedType === \\"function\\" ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired ? babelPluginFlowReactPropTypes_proptype_NamedType.isRequired : babelPluginFlowReactPropTypes_proptype_NamedType : require(\\"prop-types\\").shape(babelPluginFlowReactPropTypes_proptype_NamedType).isRequired,
@@ -43,7 +45,8 @@ var babelPluginFlowReactPropTypes_proptype_X = Object.assign({}, babelPluginFlow
 });
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
   value: babelPluginFlowReactPropTypes_proptype_X,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-export-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-export-test.js.snap
@@ -22,7 +22,8 @@ var babelPluginFlowReactPropTypes_proptype_U = Object.assign({}, babelPluginFlow
 });
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: babelPluginFlowReactPropTypes_proptype_U,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-and-nested-imported-type.js.snap
@@ -16,7 +16,8 @@ var babelPluginFlowReactPropTypes_proptype_ExportedType = {
 };
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
   value: babelPluginFlowReactPropTypes_proptype_ExportedType,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var MyComponent = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
+++ b/src/__tests__/__snapshots__/intersection-inline-with-exported-type.js.snap
@@ -14,7 +14,8 @@ var babelPluginFlowReactPropTypes_proptype_ExportedType = {
 };
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_ExportedType\\", {
   value: babelPluginFlowReactPropTypes_proptype_ExportedType,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var MyComponent = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
@@ -22,7 +22,8 @@ var babelPluginFlowReactPropTypes_proptype_X = Object.assign({}, babelPluginFlow
 });
 if (typeof exports !== \\"undefined\\") Object.defineProperty(exports, \\"babelPluginFlowReactPropTypes_proptype_X\\", {
    value: babelPluginFlowReactPropTypes_proptype_X,
-   configurable: true
+   configurable: true,
+   enumerable: true
 });
 
 var D = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-literals.js.snap
@@ -21,7 +21,8 @@ var babelPluginFlowReactPropTypes_proptype_U = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: babelPluginFlowReactPropTypes_proptype_U,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
+++ b/src/__tests__/__snapshots__/intersection-two-exported-object-type-mixed-literal-type-alias.js.snap
@@ -20,7 +20,8 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var C = function (_React$Component) {

--- a/src/__tests__/__snapshots__/string-literal-property.js.snap
+++ b/src/__tests__/__snapshots__/string-literal-property.js.snap
@@ -9,6 +9,7 @@ var babelPluginFlowReactPropTypes_proptype_T = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_T', {
   value: babelPluginFlowReactPropTypes_proptype_T,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/typeof-test.js.snap
+++ b/src/__tests__/__snapshots__/typeof-test.js.snap
@@ -13,6 +13,7 @@ var babelPluginFlowReactPropTypes_proptype_JumpToAction = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_JumpToAction', {
   value: babelPluginFlowReactPropTypes_proptype_JumpToAction,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });"
 `;

--- a/src/__tests__/__snapshots__/union-objects-exact.js.snap
+++ b/src/__tests__/__snapshots__/union-objects-exact.js.snap
@@ -36,7 +36,8 @@ var babelPluginFlowReactPropTypes_proptype_ExactFooProps = {
 };
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_ExactFooProps', {
   value: babelPluginFlowReactPropTypes_proptype_ExactFooProps,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var Foo = function (_React$Component) {

--- a/src/__tests__/__snapshots__/union-types-and-contants.js.snap
+++ b/src/__tests__/__snapshots__/union-types-and-contants.js.snap
@@ -19,7 +19,8 @@ var babelPluginFlowReactPropTypes_proptype_U = require('prop-types').oneOfType([
 
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_U', {
   value: babelPluginFlowReactPropTypes_proptype_U,
-  configurable: true
+  configurable: true,
+  enumerable: true
 });
 
 var Foo = function (_React$Component) {

--- a/src/index.js
+++ b/src/index.js
@@ -299,6 +299,7 @@ module.exports = function flowReactPropTypes(babel) {
               t.objectExpression([
                 t.objectProperty(t.identifier('value'), t.identifier(exportedName)),
                 t.objectProperty(t.identifier('configurable'), t.booleanLiteral(true)),
+                t.objectProperty(t.identifier('enumerable'), t.booleanLiteral(true)),
               ]),
             ]
           ));


### PR DESCRIPTION
Given:

`src/colors.js`:
```
// @flow

export const colors = {
  primary: 'primary',
  secondary: 'secondary',
  error: 'error',
};

export type Color = 'primary' | 'secondary' | 'error';
```
and `index.js`:
```
export * from './colors';
```
Since the generated `babelPluginFlowReactPropTypes_proptype_Color` is not enumerable under `exports`. It will not be exposed by the wildcard export in index.js which babel transpiles to:
```
var _colors = require('./colors');

Object.keys(_colors).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;
  Object.defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _colors[key];
    }
  });
});
```
That is `Object.keys(_colors)` only contains `colors` and not `babelPluginFlowReactPropTypes_proptype_Color`

This PR adds the enumerable descriptor to generated proptypes that are exported so that they exposed across babel's es5-to-commonjs modules transpilation.