### PR TITLE
fix: optional any types

### DIFF
--- a/src/__tests__/__snapshots__/basic-test.js.snap
+++ b/src/__tests__/__snapshots__/basic-test.js.snap
@@ -47,12 +47,12 @@ Foo.propTypes = {
   instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
   anything: function anything(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
     }
   },
   mixed: function mixed(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
     }
   },
   one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,

--- a/src/__tests__/__snapshots__/class-and-function-test.js.snap
+++ b/src/__tests__/__snapshots__/class-and-function-test.js.snap
@@ -43,7 +43,7 @@ var TaskGridHeader = function (_Component) {
 TaskGridHeader.propTypes = {
     tasksSetSort: function tasksSetSort(props, propName, componentName) {
         if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-            throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+            throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
         }
     }
 };

--- a/src/__tests__/__snapshots__/flow-53-generic-test.js.snap
+++ b/src/__tests__/__snapshots__/flow-53-generic-test.js.snap
@@ -43,7 +43,7 @@ var TaskGridHeader = function (_Component) {
 TaskGridHeader.propTypes = {
     tasksSetSort: function tasksSetSort(props, propName, componentName) {
         if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-            throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+            throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
         }
     }
 };

--- a/src/__tests__/__snapshots__/function-with-existential-type-test.js.snap
+++ b/src/__tests__/__snapshots__/function-with-existential-type-test.js.snap
@@ -7,7 +7,7 @@ var C = function C(props) {};
 C.propTypes = {
   bar: function bar(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error(\\"Prop \`\\" + propName + \\"\` has type 'any', but was not provided to \`\\" + componentName + \\"\`. Pass undefined or any other value.\\");
+      throw new Error(\\"Prop \`\\" + propName + \\"\` has type 'any' or 'mixed', but was not provided to \`\\" + componentName + \\"\`. Pass undefined or any other value.\\");
     }
   }
 };"

--- a/src/__tests__/__snapshots__/intersection-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-test.js.snap
@@ -24,7 +24,7 @@ var MyComponent = function (_React$Component) {
 MyComponent.propTypes = {
     someProp: function someProp(props, propName, componentName) {
         if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-            throw new Error(\\"Prop \`\\" + propName + \\"\` has type 'any', but was not provided to \`\\" + componentName + \\"\`. Pass undefined or any other value.\\");
+            throw new Error(\\"Prop \`\\" + propName + \\"\` has type 'any' or 'mixed', but was not provided to \`\\" + componentName + \\"\`. Pass undefined or any other value.\\");
         }
     }
 };"

--- a/src/__tests__/__snapshots__/optional-any-test.js.snap
+++ b/src/__tests__/__snapshots__/optional-any-test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`optional-any 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Foo = function Foo(props) {
+  return _react2.default.createElement('div', null);
+};
+Foo.propTypes = {
+  requiredAny: function requiredAny(props, propName, componentName) {
+    if (!Object.prototype.hasOwnProperty.call(props, propName)) {
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+    }
+  },
+  optionalAny: require('prop-types').any
+};
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/stateless-inline-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-inline-test.js.snap
@@ -27,7 +27,7 @@ Foo.propTypes = {
   instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
   anything: function anything(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
     }
   },
   one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,

--- a/src/__tests__/__snapshots__/stateless-test.js.snap
+++ b/src/__tests__/__snapshots__/stateless-test.js.snap
@@ -26,7 +26,7 @@ Foo.propTypes = {
   instance_of_Bar: typeof Bar === 'function' ? require('prop-types').instanceOf(Bar).isRequired : require('prop-types').any.isRequired,
   anything: function anything(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
     }
   },
   one_of: require('prop-types').oneOf(['QUACK', 'BARK', 5]).isRequired,

--- a/src/__tests__/__snapshots__/tupletype-test.js.snap
+++ b/src/__tests__/__snapshots__/tupletype-test.js.snap
@@ -15,10 +15,6 @@ function Foo(props) {
 }
 Foo.propTypes = {
   an_optional_string: require('prop-types').string,
-  tupletype: require('prop-types').arrayOf(function (props, propName, componentName) {
-    if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
-    }
-  }).isRequired
+  tupletype: require('prop-types').arrayOf(require('prop-types').any).isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/typeof-test.js.snap
+++ b/src/__tests__/__snapshots__/typeof-test.js.snap
@@ -10,7 +10,7 @@ var ActionTypes = {
 var babelPluginFlowReactPropTypes_proptype_JumpToAction = {
   type: function type(props, propName, componentName) {
     if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
+      throw new Error('Prop \`' + propName + '\` has type \\\\'any\\\\' or \\\\'mixed\\\\', but was not provided to \`' + componentName + '\`. Pass undefined or any other value.');
     }
   },
   index: require('prop-types').number.isRequired

--- a/src/__tests__/optional-any-test.js
+++ b/src/__tests__/optional-any-test.js
@@ -1,0 +1,21 @@
+const babel = require('babel-core');
+const content = `
+import React from 'react';
+
+type Props = {
+  requiredAny: any,
+  optionalAny?: any,
+};
+
+const Foo = (props: Props) => <div />
+export default Foo
+`;
+
+it('optional-any', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -30,7 +30,7 @@ const exactTemplate = template(`
 const anyTemplate = template(`
 (props, propName, componentName) => {
   if (!Object.prototype.hasOwnProperty.call(props, propName)) {
-    throw new Error(\`Prop \\\`\${propName}\\\` has type 'any', but was not provided to \\\`\${componentName\}\\\`. Pass undefined or any other value.\`);
+    throw new Error(\`Prop \\\`\${propName}\\\` has type 'any' or 'mixed', but was not provided to \\\`\${componentName\}\\\`. Pass undefined or any other value.\`);
   }
 }
 `);
@@ -275,7 +275,13 @@ function makePropType(data, isExact) {
   }
   else if (method === 'any') {
     markFullExpressionAsRequired = false;
-    node = anyTemplate().expression;
+    
+    if (data.isRequired) {
+      node = anyTemplate().expression;
+    }
+    else {
+      node = t.memberExpression(node, t.identifier(method));
+    }
   }
   else if (method === 'raw') {
     markFullExpressionAsRequired = false;


### PR DESCRIPTION
Fixes the following scenario:

```
type Props = {
   foo?: any,
}

const MyComp = (props: Props) => <div />
```

Outputs:

```
MyComp.propTypes = {
  foo: require('prop-types').any,
}
```

Fixes #142.

@brigand Does this seem right to you?