### PR TITLE
Add context types

### DIFF
--- a/src/__tests__/__snapshots__/context-component-no-props-test.js.snap
+++ b/src/__tests__/__snapshots__/context-component-no-props-test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`allows class components with context and no props 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement('div', null);
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.contextTypes = {
+  lang: require('prop-types').string.isRequired
+};
+;
+
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/context-component-test.js.snap
+++ b/src/__tests__/__snapshots__/context-component-test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`allows specifying both props and context 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement('div', null);
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.contextTypes = {
+  lang: require('prop-types').string.isRequired
+};
+Foo.propTypes = {
+  x: require('prop-types').oneOf(['option1', 'option2'])
+};
+;
+
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/context-parametrized-component-test.js.snap
+++ b/src/__tests__/__snapshots__/context-parametrized-component-test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`allows specifying both props and context via parameters 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement('div', null);
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.contextTypes = {
+  lang: require('prop-types').string.isRequired
+};
+Foo.propTypes = {
+  x: require('prop-types').oneOf(['option1', 'option2'])
+};
+;
+
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/context-stateless-arrow-test.js.snap
+++ b/src/__tests__/__snapshots__/context-stateless-arrow-test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parses second argument as contextTypes 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+});
+
+var React = require('react');
+
+var Foo = function Foo(props, context) {
+    React.createElement(
+        'div',
+        null,
+        props.x
+    );
+};
+
+Foo.contextTypes = {
+    lang: require('prop-types').string.isRequired
+};
+Foo.propTypes = {
+    x: require('prop-types').oneOf(['option1', 'option2'])
+};
+exports.default = Foo;"
+`;

--- a/src/__tests__/context-component-no-props-test.js
+++ b/src/__tests__/context-component-no-props-test.js
@@ -1,0 +1,33 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+type FooC = {
+    lang: string,
+};
+
+class Foo extends React.Component {
+  context: FooC;
+  
+  render() {
+    return <div />;
+  }
+};
+
+export default Foo;
+`;
+
+it('allows class components with context and no props', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/context-component-test.js
+++ b/src/__tests__/context-component-test.js
@@ -1,0 +1,34 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+type FooC = {
+    lang: string,
+};
+
+class Foo extends React.Component {
+  props: FooT;
+  context: FooC;
+  
+  render() {
+    return <div />;
+  }
+};
+
+export default Foo;
+`;
+
+it('allows specifying both props and context', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/context-parametrized-component-test.js
+++ b/src/__tests__/context-parametrized-component-test.js
@@ -1,0 +1,31 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+type FooC = {
+    lang: string,
+};
+
+class Foo extends React.Component<void, FooT, FooC> {
+  render() {
+    return <div />;
+  }
+};
+
+export default Foo;
+`;
+
+it('allows specifying both props and context via parameters', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/context-stateless-arrow-test.js
+++ b/src/__tests__/context-stateless-arrow-test.js
@@ -1,0 +1,29 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Choices = 'option1' | 'option2';
+
+type FooT = {
+    x?: Choices
+};
+
+type FooC = {
+    lang: string,
+};
+
+const Foo = (props: FooT, context: FooC) => {
+  <div>{props.x}</div>
+};
+
+export default Foo;
+`;
+
+it('parses second argument as contextTypes', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR proposes `contextTypes` generation from Flow annotations.

Resolves #63 

Supported & tested use cases:

* Stateless functional component
* `React.Component` with `context` as an attribute