### PR TITLE
Dead code part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ returns a truthy value, then the propTypes will be removed. This works because e
 Example of specifying a custom expression:
 
 ```json
-  "plugins": [["flow-react-proptypes", { "deadCode": "__DEV__" }]]
+  "plugins": [["flow-react-proptypes", { "deadCode": "__PROD__" }]]
 ```
 
 ## Suppression

--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ Add the option to your babel config.
   "plugins": [["flow-react-proptypes", { "useStatic": true }]]
 }
 
+## deadCode
+
+The deadCode option (disabled by default) adds a predicate to the code allowing both your propTypes definitions and potentially the
+entire 'prop-types' package to be excluded in certain builds. Unlike specifying this plugin in the development env, mentioned above,
+this also works for packages published to npm.
+
+```json
+  "plugins": [["flow-react-proptypes", { "deadCode": true }]]
+```
+
+The value of `true` is short for `process.env.NODE_ENV === 'production'`. You can alternatively pass any JavaScript expression. If the expression
+returns a truthy value, then the propTypes will be removed. This works because e.g. webpack will subsitute the value of `process.env.NODE_ENV` with `'production'`, resulting in the condition being `'production' === 'production'`, and then a minifer sees that the code we're generating can't be executed, and strips it, and the `require('prop-types')` code out of the final bundle.
+
+Example of specifying a custom expression:
+
+```json
+  "plugins": [["flow-react-proptypes", { "deadCode": "__DEV__" }]]
+```
+
 ## Suppression
 This plugin isn't perfect. You can disable it for an entire file with this directive (including quotes):
 

--- a/a.js
+++ b/a.js
@@ -1,9 +1,0 @@
-import React, { Component } from "react"
-import { View } from "react-native"
-
-type Props = { test: string }
-export default class App extends Component<Props> {
-  render() {
-    return 'span'
-  }
-}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "jest-environment-node-debug": "^2.0.0",
     "prettier": "^1.4.4",
     "react": "^15.5.4",
-    "react-test-renderer": "^15.5.4"
+    "react-test-renderer": "^15.5.4",
+    "uglify-js": "^3.2.2"
   },
   "dependencies": {
     "babel-core": "^6.25.0",

--- a/scripts/runOnFile
+++ b/scripts/runOnFile
@@ -32,7 +32,7 @@ if (process.argv.includes('--rn')) {
   babelConfig = {
     babelrc: false,
     presets: ['es2015', 'stage-1', 'react'],
-    plugins: ['syntax-flow', [self, { "useStatic": true}]],
+    plugins: ['syntax-flow', [self, { "useStatic": true, deadCode: '__DEV__' }]],
   };
 }
 

--- a/src/__tests__/__snapshots__/dead-code-exports-test.js.snap
+++ b/src/__tests__/__snapshots__/dead-code-exports-test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dead-code-exports 1`] = `
+"'use strict';
+
+var React = require('react');
+
+var babelPluginFlowReactPropTypes_proptype_MyType = __PROD__ ? null : require('prop-types').oneOfType([require('prop-types').string, require('prop-types').number]);
+if (!__PROD__ && typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_MyType', {
+  value: babelPluginFlowReactPropTypes_proptype_MyType,
+  configurable: true
+});"
+`;
+
+exports[`dead-code-exports uglify 1`] = `"\\"use strict\\";require(\\"react\\");"`;

--- a/src/__tests__/__snapshots__/dead-code-string-test.js.snap
+++ b/src/__tests__/__snapshots__/dead-code-string-test.js.snap
@@ -8,7 +8,7 @@ var React = require('react');
 var Foo = function Foo(props) {
   return React.createElement('div', null);
 };
-Foo.propTypes = __DEV__ ? null : {
+Foo.propTypes = __PROD__ ? null : {
   x: require('prop-types').string.isRequired
 };"
 `;

--- a/src/__tests__/__snapshots__/dead-code-string-test.js.snap
+++ b/src/__tests__/__snapshots__/dead-code-string-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dead-code-string 1`] = `
+"'use strict';
+
+var React = require('react');
+
+var Foo = function Foo(props) {
+  return React.createElement('div', null);
+};
+Foo.propTypes = __DEV__ ? null : {
+  x: require('prop-types').string.isRequired
+};"
+`;

--- a/src/__tests__/__snapshots__/dead-code-true-test.js.snap
+++ b/src/__tests__/__snapshots__/dead-code-true-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dead-code-true 1`] = `
+"'use strict';
+
+var React = require('react');
+
+var Foo = function Foo(props) {
+  return React.createElement('div', null);
+};
+Foo.propTypes = process.env.NODE_ENV === 'production' ? null : {
+  x: require('prop-types').string.isRequired
+};"
+`;

--- a/src/__tests__/__snapshots__/dead-code-true-test.js.snap
+++ b/src/__tests__/__snapshots__/dead-code-true-test.js.snap
@@ -12,3 +12,5 @@ Foo.propTypes = process.env.NODE_ENV === 'production' ? null : {
   x: require('prop-types').string.isRequired
 };"
 `;
+
+exports[`dead-code-true uglify 1`] = `"\\"use strict\\";var e=require(\\"react\\");(function(r){return e.createElement(\\"div\\",null)}).propTypes=null;"`;

--- a/src/__tests__/dead-code-exports-test.js
+++ b/src/__tests__/dead-code-exports-test.js
@@ -3,8 +3,8 @@ const { minify } = require('uglify-js');
 const content = `
 var React = require('react');
 
-type Props = { x: string };
-const Foo = (props: Props) => <div />;
+export type MyType = string | number;
+
 `;
 
 const opts = {
@@ -13,15 +13,16 @@ const opts = {
   plugins: ['syntax-flow', [require('../'), { deadCode: '__PROD__' }]],
 };
 
-it('dead-code-string', () => {
+it('dead-code-exports', () => {
   const res = babel.transform(content, opts).code;
-  expect(res).toMatch(/__PROD__\s*\?/);
+  expect(res).toMatch(/__PROD__/);
   expect(res).toMatchSnapshot();
 });
 
-it('dead-code-string uglify', () => {
+it('dead-code-exports uglify', () => {
   const res = babel.transform(content, opts).code
-    .replace(/__PROD__/, 'true');
+    .replace(/__PROD__/g, 'true');
   const { code: min } = minify(res, { toplevel: true });
   expect(min).not.toMatch(/prop-types/);
+  expect(min).toMatchSnapshot();
 });

--- a/src/__tests__/dead-code-string-test.js
+++ b/src/__tests__/dead-code-string-test.js
@@ -1,0 +1,17 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Props = { x: string };
+const Foo = (props: Props) => <div />;
+`;
+
+it('dead-code-string', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', [require('../'), { deadCode: '__DEV__' }]],
+  }).code;
+  expect(res).toMatch(/__DEV__\s*\?/);
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/dead-code-true-test.js
+++ b/src/__tests__/dead-code-true-test.js
@@ -1,0 +1,17 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Props = { x: string };
+const Foo = (props: Props) => <div />;
+`;
+
+it('dead-code-true', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', [require('../'), { deadCode: true }]],
+  }).code;
+  expect(res).toMatch(/\.NODE_ENV[^]{1,10}production[^]{1,7}\?/);
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/dead-code-true-test.js
+++ b/src/__tests__/dead-code-true-test.js
@@ -1,4 +1,5 @@
 const babel = require('babel-core');
+const { minify } = require('uglify-js');
 const content = `
 var React = require('react');
 
@@ -6,12 +7,21 @@ type Props = { x: string };
 const Foo = (props: Props) => <div />;
 `;
 
+const opts = {
+  babelrc: false,
+  presets: ['es2015', 'stage-1', 'react'],
+  plugins: ['syntax-flow', [require('../'), { deadCode: true }]],
+};
+
 it('dead-code-true', () => {
-  const res = babel.transform(content, {
-    babelrc: false,
-    presets: ['es2015', 'stage-1', 'react'],
-    plugins: ['syntax-flow', [require('../'), { deadCode: true }]],
-  }).code;
+  const res = babel.transform(content, opts).code;
   expect(res).toMatch(/\.NODE_ENV[^]{1,10}production[^]{1,7}\?/);
   expect(res).toMatchSnapshot();
+});
+
+it('dead-code-true uglify', () => {
+  const res = babel.transform(content, opts).code
+    .replace(/process.env.NODE_ENV/, '"production"');
+  const { code: min } = minify(res, { toplevel: true });
+  expect(min).not.toMatch(/prop-types/);
 });

--- a/src/__tests__/dead-code-true-test.js
+++ b/src/__tests__/dead-code-true-test.js
@@ -24,4 +24,5 @@ it('dead-code-true uglify', () => {
     .replace(/process.env.NODE_ENV/, '"production"');
   const { code: min } = minify(res, { toplevel: true });
   expect(min).not.toMatch(/prop-types/);
+  expect(min).toMatchSnapshot();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,7 +1167,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.9.0:
+commander@^2.11.0, commander@^2.9.0, commander@~2.12.1:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
@@ -3414,6 +3414,10 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -3641,6 +3645,13 @@ uglify-js@^2.6:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.2.tgz#870e4b34ed733d179284f9998efd3293f7fd73f6"
+  dependencies:
+    commander "~2.12.1"
+    source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Partially resolves #70 #154

Done:

- added `deadCode` config option (see readme)
- dce for the propTypes object
- dce for exported types (`export type Foo =`)

Remaining (PRs welcome)

- dce for imported types (`import type {Foo} from './Foo`)
- dce for the actual 'propTypes' property, both with the default assignment at end of file, and the the `useStatic` option (currently `propTypes=null` after minify)

If anyone picks up these tasks, see `src/__tests__/dead-code-true-test.js` for an example of a test that uses uglify to test the minified output.

cc @sohkai