### PR TITLE
fix(templates): Stricter substitution usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,10 +89,10 @@ module.exports = function flowReactPropTypes(babel) {
         let toAdd = null;
 
         if (type === 'default') {
-          toAdd = impTemplates.default({ NAME: tid(local), LOCAL: tid(local) });
+          toAdd = impTemplates.default({ NAME: tid(local) });
         }
         else if (type === 'named') {
-          toAdd = impTemplates.named({ LOCAL: tid(local), NAME: tid(name) });
+          toAdd = impTemplates.named({ LOCAL: tid(local) });
         }
         if (toAdd) {
           toAdd.source.value = location;


### PR DESCRIPTION
Overview
--------

While upgrading this plugin to v14 in a codebase that uses Babel v7 (beta), we encountered this error:

```
Error: Unknown substitution "NAME" given
    at /home/spainhower/repos/hz-wl-webapps/node_modules/@babel/template/lib/populate.js:21:15
        at Array.forEach (<anonymous>)
            at populatePlaceholders (/home/spainhower/repos/hz-wl-webapps/node_modules/@babel/template/lib/populate.js:19:31)
                at /home/spainhower/repos/hz-wl-webapps/node_modules/@babel/template/lib/string.js:20:51
                    at Object.named (/home/spainhower/repos/hz-wl-webapps/node_modules/@babel/template/lib/builder.js:83:14)
```

It appears that babel v7 templates are more strict regarding the substitutions with which they are called.  All provided substitutions must be used in the template.  This PR just tightens up those calls to template compilation.

Changes
-------

- Do not provide unused subs to babel templates
    - Fixes Babel v7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brigand/babel-plugin-flow-react-proptypes/166)
<!-- Reviewable:end -->
