### PR TITLE
fix(annotate) Set name for path Class types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,6 +250,7 @@ module.exports = function flowReactPropTypes(babel) {
     let targetPath;
 
     if (!opts.noStatic && (path.type === 'ClassDeclaration' || path.type === 'ClassExpression')) {
+      name = path.node.id.name;
       targetPath = path;
     }
     else if (path.type === 'ArrowFunctionExpression' || path.type === 'FunctionExpression') {


### PR DESCRIPTION
Set name variable to path.node.id.name when path.type matches ClassDeclaration or ClassExpression

We were seeing the following error because `name` is undefined when `path.type` is `ClassDeclaration` or `ClassExpression`, and `name` is a required field for the babel-types identifier call. 

https://github.com/brigand/babel-plugin-flow-react-proptypes/blob/master/src/index.js#L218
https://github.com/babel/babel/tree/master/packages/babel-types#identifier

```sh
TypeError: Property name expected type of string but got null
    at validate (/home/circleci/repo/node_modules/@babel/types/lib/definitions/utils.js:175:13)
    at Object.validate (/home/circleci/repo/node_modules/@babel/types/lib/definitions/utils.js:191:10)
    at validate (/home/circleci/repo/node_modules/@babel/types/lib/validators/validate.js:15:9)
    at builder (/home/circleci/repo/node_modules/@babel/types/lib/builders/builder.js:40:27)
    at Object.Identifier (/home/circleci/repo/node_modules/@babel/types/lib/builders/generated/index.js:381:27)
    at addAnnotationsToAST (/home/circleci/repo/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:204:101)
    at annotate (/home/circleci/repo/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:247:7)
    at PluginPass.ClassExpressionClassDeclaration (/home/circleci/repo/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:414:9)
    at newFn (/home/circleci/repo/node_modules/@babel/traverse/lib/visitors.js:223:21)
    at NodePath._call (/home/circleci/repo/node_modules/@babel/traverse/lib/path/context.js:64:19)
```