### PR TITLE
"fix" for Generics on functions

### DIFF
--- a/src/__tests__/__snapshots__/real2-test.js.snap
+++ b/src/__tests__/__snapshots__/real2-test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`real2 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+exports.default = function (Component) {
+    var _class, _temp;
+
+    var componentName = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : Component.displayName || Component.name;
+
+    return _temp = _class = function (_React$PureComponent) {
+        _inherits(PureStateless, _React$PureComponent);
+
+        function PureStateless() {
+            _classCallCheck(this, PureStateless);
+
+            return _possibleConstructorReturn(this, (PureStateless.__proto__ || Object.getPrototypeOf(PureStateless)).apply(this, arguments));
+        }
+
+        _createClass(PureStateless, [{
+            key: 'render',
+
+            // $FlowFixMe
+            value: function render() {
+                return Component(this.props, this.context);
+            }
+            // $FlowFixMe
+
+        }]);
+
+        return PureStateless;
+    }(React.PureComponent), _class.defaultProps = Component.defaultProps, _class.displayName = 'PureStateless(' + componentName + ')', _class.contextTypes = Component.contextTypes, _class.propTypes = Component.propTypes, _temp;
+};
+
+var _react = require('react');
+
+var React = _interopRequireWildcard(_react);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }"
+`;

--- a/src/__tests__/real2-test.js
+++ b/src/__tests__/real2-test.js
@@ -1,0 +1,33 @@
+const babel = require('babel-core');
+const content = `
+// @flow
+import * as React from 'react';
+
+export default function<P: {}>(
+    Component: React.StatelessFunctionalComponent<P>,
+    componentName: string = Component.displayName || Component.name
+): React.ComponentType<*> {
+    return class PureStateless extends React.PureComponent<P> {
+        // $FlowFixMe
+        static defaultProps = Component.defaultProps;
+        static displayName = \`PureStateless(\${componentName})\`;
+        static contextTypes = Component.contextTypes;
+        // $FlowFixMe
+        static propTypes = Component.propTypes;
+        context: any;
+        render() {
+            return Component(this.props, this.context);
+        }
+    };
+}
+
+`;
+
+it('real2', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,8 @@ module.exports = function flowReactPropTypes(babel) {
           if (typeAliasName === 'Object') return;
           const props = internalTypes[typeAliasName] || (importedTypes[typeAliasName] && importedTypes[typeAliasName].accessNode);
           if (!props) {
-            throw new TypeError(`Couldn't find type "${typeAliasName}"`);
+            $debug(`Couldn't find type "${typeAliasName}"`);
+            return;
           }
 
           propTypes = props;


### PR DESCRIPTION
Basically this includes a file from my work that crashed the plugin.
Instead of crashing we now ignore a property that wasn't found.