### PR TITLE
Fixed case with imported types with different local name

### DIFF
--- a/src/__tests__/__snapshots__/import-imported-clash.js.snap
+++ b/src/__tests__/__snapshots__/import-imported-clash.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import-imported-clash 1`] = `
+"'use strict';
+
+var _foo = require('./foo');
+
+var _bar = require('./bar');
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var C = function (_React$Component) {
+  _inherits(C, _React$Component);
+
+  function C() {
+    _classCallCheck(this, C);
+
+    return _possibleConstructorReturn(this, (C.__proto__ || Object.getPrototypeOf(C)).apply(this, arguments));
+  }
+
+  return C;
+}(React.Component);
+
+C.propTypes = {
+  foo: function foo() {
+    return (typeof _foo.bpfrpt_proptype_Foo === 'function' ? _foo.bpfrpt_proptype_Foo.isRequired ? _foo.bpfrpt_proptype_Foo.isRequired : _foo.bpfrpt_proptype_Foo : _propTypes2.default.shape(_foo.bpfrpt_proptype_Foo).isRequired).apply(this, arguments);
+  },
+  bar: function bar() {
+    return (typeof _bar.bpfrpt_proptype_Foo === 'function' ? _bar.bpfrpt_proptype_Foo.isRequired ? _bar.bpfrpt_proptype_Foo.isRequired : _bar.bpfrpt_proptype_Foo : _propTypes2.default.shape(_bar.bpfrpt_proptype_Foo).isRequired).apply(this, arguments);
+  }
+};
+;"
+`;

--- a/src/__tests__/import-imported-clash.js
+++ b/src/__tests__/import-imported-clash.js
@@ -1,0 +1,23 @@
+const babel = require('babel-core');
+const content = `
+import type {Foo} from './foo';
+import type {Foo as Bar} from './bar';
+
+type Props = {
+  foo: Foo,
+  bar: Bar,
+};
+
+class C extends React.Component {
+    props: Props
+};
+`;
+
+it('import-imported-clash', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});


### PR DESCRIPTION
This fixes #176. Got suddenly sleepy a lot and couldn't get my mind into the game so variable naming and code structure probably could be a little bit better, but unfortunately I have to get to other things right now. 

I suspect (didnt check) that this issue also affects other cases:
- cjs style - I havent touched that branch of the code
- `export type { Foo as Bar } from './foo'`

I can work on those, but certainly not before the weekend and also not sure how much time I will have then, so feel free to pick up this if you want from where I left - if you have any comments regarding changes in this PR I will find some time to adjust it based on your suggestions.