### PR TITLE
[Babel7] Compat for intersection & imported types

### DIFF
--- a/src/__tests__/__snapshots__/real3-test.js.snap
+++ b/src/__tests__/__snapshots__/real3-test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`real3 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+});
+exports.bpfrpt_proptype_JobViewImpression = undefined;
+
+var _JLCommon = require('JLCommon');
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var bpfrpt_proptype_JobViewImpression = Object.assign({}, _JLCommon.bpfrpt_proptype_Job === _propTypes2.default.any ? {} : _JLCommon.bpfrpt_proptype_Job, {
+    resultId: _propTypes2.default.string,
+    listIndex: _propTypes2.default.number.isRequired,
+    searchType: _propTypes2.default.string,
+    viewSource: _propTypes2.default.string
+});
+exports.bpfrpt_proptype_JobViewImpression = bpfrpt_proptype_JobViewImpression;"
+`;

--- a/src/__tests__/real3-test.js
+++ b/src/__tests__/real3-test.js
@@ -1,0 +1,20 @@
+const babel = require('babel-core');
+const content = `
+// @flow
+import type { Job } from 'JLCommon';
+export type JobViewImpression = Job & {
+    resultId?: string,
+    listIndex: number,
+    searchType: ?string,
+    viewSource: ?string,
+};
+`;
+
+it('real3', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -114,7 +114,7 @@ function makeObjectAstForRaw(propTypeSpec, propTypeObjects) {
   // which will not work when used in an intersection.
   const anyNode = makeAnyPropTypeAST();
   const testExpression = t.binaryExpression('===', propTypeObject, anyNode);
-  propTypeObject = t.conditionalExpression(testExpression, t.objectExpression([]), propTypeObject);
+  propTypeObject = t.conditionalExpression(testExpression, t.objectExpression([]), t.cloneDeep(propTypeObject));
   return propTypeObject;
 }
 /**


### PR DESCRIPTION
In Babel7 the identifier has to be cloned to get the import Name prefix.

For the intersection babel7 would generate the following code:
```js
var bpfrpt_proptype_JobViewImpression = Object.assign({}, _JLCommon.bpfrpt_proptype_Job === _propTypes2.default.any ? {} : bpfrpt_proptype_Job, {
    resultId: _propTypes2.default.string,
    listIndex: _propTypes2.default.number.isRequired,
    searchType: _propTypes2.default.string,
    viewSource: _propTypes2.default.string
});
```

As you can see the```_JLCommon``` is missing on the second ```bpfrpt_proptype_Job``` this is because both ```bpfrpt_proptype_Job```were the same node before. Now I clone it.
Babel7 no longer adjusts both identifier if it was the same node.