### PR TITLE
Add support for indexed objects (`objectOf`)

### DIFF
--- a/src/__tests__/__snapshots__/objectof-test.js.snap
+++ b/src/__tests__/__snapshots__/objectof-test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`objectOf 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  oneNumber: _propTypes2.default.number.isRequired,
+  oneComplex: _propTypes2.default.shape({
+    real: _propTypes2.default.number.isRequired,
+    imag: _propTypes2.default.number.isRequired
+  }).isRequired,
+  manyNumbers: _propTypes2.default.objectOf(_propTypes2.default.number).isRequired,
+  manyComplex: _propTypes2.default.objectOf(_propTypes2.default.shape({
+    real: _propTypes2.default.number.isRequired,
+    imag: _propTypes2.default.number.isRequired
+  })).isRequired
+};
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/real4-test.js.snap
+++ b/src/__tests__/__snapshots__/real4-test.js.snap
@@ -42,7 +42,11 @@ var bpfrpt_proptype_searchPostResult = {
     total: _propTypes2.default.number.isRequired,
     pages: _propTypes2.default.number.isRequired,
     resultId: _propTypes2.default.string.isRequired,
-    facets: _propTypes2.default.shape({})
+    facets: _propTypes2.default.objectOf(_propTypes2.default.arrayOf(_propTypes2.default.shape({
+        key: _propTypes2.default.number.isRequired,
+        amount: _propTypes2.default.number.isRequired,
+        translation: _propTypes2.default.string.isRequired
+    })))
 };
 
 // eslint-disable-next-line

--- a/src/__tests__/objectof-mixed-indexers-named-test.js
+++ b/src/__tests__/objectof-mixed-indexers-named-test.js
@@ -1,0 +1,20 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type FooProps = {
+  problem: {[name: string]: number, special: string},
+}
+
+export default class Foo extends React.Component {
+  props: FooProps
+}
+`;
+
+it('objectOf rejects multiple indexers', () => {
+  expect(() => babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  })).toThrow(/mixed indexers and named properties are not supported/i);
+});

--- a/src/__tests__/objectof-multiple-indexers-test.js
+++ b/src/__tests__/objectof-multiple-indexers-test.js
@@ -1,0 +1,20 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type FooProps = {
+  problem: {[name: string]: number, [nombre: string]: bool},
+}
+
+export default class Foo extends React.Component {
+  props: FooProps
+}
+`;
+
+it('objectOf rejects multiple indexers', () => {
+  expect(() => babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  })).toThrow(/multiple indexers are not supported/i);
+});

--- a/src/__tests__/objectof-test.js
+++ b/src/__tests__/objectof-test.js
@@ -1,0 +1,28 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+
+type Complex = {
+  real: number;
+  imag: number;
+}
+type FooProps = {
+  oneNumber: number;
+  oneComplex: Complex;
+  manyNumbers: {[name: string]: number},
+  manyComplex: {[name: string]: Complex},
+}
+
+export default class Foo extends React.Component {
+  props: FooProps
+}
+`;
+
+it('objectOf', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/makePropTypesAst.js
+++ b/src/makePropTypesAst.js
@@ -347,6 +347,12 @@ function makePropType(data, isExact) {
       [makePropType(data.of)]
     );
   }
+  else if (method === 'objectOf') {
+    node = t.callExpression(
+      t.memberExpression(node, t.identifier('objectOf')),
+      [makePropType(data.of)]
+    );
+  }
   else if (method === 'oneOf') {
     node = t.callExpression(
       t.memberExpression(node, t.identifier('oneOf')),


### PR DESCRIPTION
Summary:
This commit adds support for types like `{[name: string]: number}`,
which describes an object with arbitrary keys and numeric values. The
corresponding PropType is `PropTypes.objectOf(PropTypes.number)`.

Two variants are rejected outright. First, Flow does not support types
with multiple indexers: `{[a: string]: number, [b: string]: number}` is
not a valid type expression. You can verify this by pasting the
following into the Flow playground:
```
type X = {[a: string]: number, [b: string]: number};
```
This gives the error:
```
1: type X = {[a: string]: number, [b: string]: number};
                                  ^ Multiple indexers are not supported.
```
It therefore seems reasonable to reject any such type expressions that
make it into the AST.

On the other hand, Flow _does_ support mixing indexers and named
properties. For instance, `{[name: string]: number, special: boolean}`
is a valid Flow type. But there’s no corresponding PropType, so we will
reject this outright.

Test Plan:
The test case `objectof-test.js` passes.

This commit caused a “regression” in `real4-test.js`, because the source
of `real4-test` actually uses indexed objects. I’ve regenerated the
snapshot to account for this.

wchargin-branch: objectof