### PR TITLE
No import node modules 181

### DIFF
--- a/src/__tests__/__snapshots__/import-component-type-from-react-test.js.snap
+++ b/src/__tests__/__snapshots__/import-component-type-from-react-test.js.snap
@@ -7,10 +7,6 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _propTypes = require('prop-types');
-
-var _propTypes2 = _interopRequireDefault(_propTypes);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }

--- a/src/__tests__/__snapshots__/import-non-relative.js.snap
+++ b/src/__tests__/__snapshots__/import-non-relative.js.snap
@@ -3,10 +3,6 @@
 exports[`import-object 1`] = `
 "'use strict';
 
-var _foo = require('foo');
-
-var _bar = require('bar');
-
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -33,10 +29,10 @@ var C = function (_React$Component) {
 
 C.propTypes = {
   an_imported_named_type: function an_imported_named_type() {
-    return (typeof _foo.bpfrpt_proptype_NamedType === 'function' ? _foo.bpfrpt_proptype_NamedType.isRequired ? _foo.bpfrpt_proptype_NamedType.isRequired : _foo.bpfrpt_proptype_NamedType : _propTypes2.default.shape(_foo.bpfrpt_proptype_NamedType).isRequired).apply(this, arguments);
+    return (typeof NamedType === 'function' ? _propTypes2.default.instanceOf(NamedType).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);
   },
   an_imported_default_type: function an_imported_default_type() {
-    return (typeof _bar.bpfrpt_proptype_DefaultType === 'function' ? _bar.bpfrpt_proptype_DefaultType.isRequired ? _bar.bpfrpt_proptype_DefaultType.isRequired : _bar.bpfrpt_proptype_DefaultType : _propTypes2.default.shape(_bar.bpfrpt_proptype_DefaultType).isRequired).apply(this, arguments);
+    return (typeof DefaultType === 'function' ? _propTypes2.default.instanceOf(DefaultType).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);
   },
   a_global_type: function a_global_type() {
     return (typeof Date === 'function' ? _propTypes2.default.instanceOf(Date).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);

--- a/src/__tests__/__snapshots__/real3-test.js.snap
+++ b/src/__tests__/__snapshots__/real3-test.js.snap
@@ -8,19 +8,17 @@ Object.defineProperty(exports, \\"__esModule\\", {
 });
 exports.bpfrpt_proptype_JobViewImpression = undefined;
 
-var _JLCommon = require('JLCommon');
-
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var bpfrpt_proptype_JobViewImpression = Object.assign({}, _JLCommon.bpfrpt_proptype_Job === _propTypes2.default.any ? {} : _JLCommon.bpfrpt_proptype_Job, {
+var bpfrpt_proptype_JobViewImpression = {
     resultId: _propTypes2.default.string,
     listIndex: _propTypes2.default.number.isRequired,
     searchType: _propTypes2.default.string,
     viewSource: _propTypes2.default.string
-});
+};
 exports.bpfrpt_proptype_JobViewImpression = bpfrpt_proptype_JobViewImpression;"
 `;

--- a/src/__tests__/__snapshots__/real4-test.js.snap
+++ b/src/__tests__/__snapshots__/real4-test.js.snap
@@ -8,11 +8,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
 });
 exports.bpfrpt_proptype_directApplyRecentFilesGet = exports.bpfrpt_proptype_directApplyDraftGet = exports.bpfrpt_proptype_loginPostResult = exports.bpfrpt_proptype_popunderPostResponse = exports.bpfrpt_proptype_jobofferGetResult = exports.bpfrpt_proptype_statisticalDataGetResult = exports.bpfrpt_proptype_freqSearchSuggestionGetResult = exports.bpfrpt_proptype_jobsearchSuggestionGetResult = exports.bpfrpt_proptype_joblocationSuggestionGetResult = exports.bpfrpt_proptype_joblocationReverseLookupGetResult = exports.bpfrpt_proptype_jobalertMeGetResult = exports.bpfrpt_proptype_searchPostResult = exports.bpfrpt_proptype_jpopunderPostResult = undefined;
 
-var _JLCommon = require('JLCommon');
+var _JLCommon = require('./JLCommon');
 
-var _DirectApply = require('reducer/DirectApply');
+var _DirectApply = require('./reducer/DirectApply');
 
-var _jobliftQueryParser = require('joblift-query-parser');
+var _jobliftQueryParser = require('./joblift-query-parser');
 
 var _propTypes = require('prop-types');
 

--- a/src/__tests__/__snapshots__/top-level-import-test.js.snap
+++ b/src/__tests__/__snapshots__/top-level-import-test.js.snap
@@ -13,12 +13,6 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _types = require('types');
-
-var _propTypes = require('prop-types');
-
-var _propTypes2 = _interopRequireDefault(_propTypes);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
@@ -52,6 +46,5 @@ var Test = function (_Component) {
   return Test;
 }(_react.Component);
 
-Test.propTypes = _types.bpfrpt_proptype_Data === _propTypes2.default.any ? {} : _types.bpfrpt_proptype_Data;
 exports.default = Test;"
 `;

--- a/src/__tests__/real4-test.js
+++ b/src/__tests__/real4-test.js
@@ -1,9 +1,9 @@
 const babel = require('babel-core');
 const content = `
 // @flow
-import type { AdPartner, Job, JobAlert, SeoText } from 'JLCommon';
-import type { DirectApplyDraft, DirectApplyFile } from 'reducer/DirectApply';
-import type { SearchQuery } from 'joblift-query-parser';
+import type { AdPartner, Job, JobAlert, SeoText } from './JLCommon';
+import type { DirectApplyDraft, DirectApplyFile } from './reducer/DirectApply';
+import type { SearchQuery } from './joblift-query-parser';
 
 // eslint-disable-next-line
 export type { SearchQuery };

--- a/src/index.js
+++ b/src/index.js
@@ -594,6 +594,8 @@ module.exports = function flowReactPropTypes(babel) {
 
         const {node} = path;
 
+        if (/^\w/.test(node.source.value)) return;
+
         // https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/62
         // if (node.source.value[0] !== '.') {
         //   return;


### PR DESCRIPTION
This ignores type imports when the path looks like a node_modules import (e.g. `'lodash'`). See #181

@marudor you added some tests recently that use non-relative imports. Would this break your stuff?

From what I can tell, this solves exactly one case: you're importing a flow type from a node_modules package, where the resolved file is an ESM, but wasn't processed by this plugin.
