### PR TITLE
Ignore namespaced node_modules

### DIFF
--- a/src/__tests__/__snapshots__/import-non-relative.js.snap
+++ b/src/__tests__/__snapshots__/import-non-relative.js.snap
@@ -31,6 +31,9 @@ C.propTypes = {
   an_imported_named_type: function an_imported_named_type() {
     return (typeof NamedType === 'function' ? _propTypes2.default.instanceOf(NamedType).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);
   },
+  an_imported_named_namespace_type: function an_imported_named_namespace_type() {
+    return (typeof NamespaceType === 'function' ? _propTypes2.default.instanceOf(NamespaceType).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);
+  },
   an_imported_default_type: function an_imported_default_type() {
     return (typeof DefaultType === 'function' ? _propTypes2.default.instanceOf(DefaultType).isRequired : _propTypes2.default.any.isRequired).apply(this, arguments);
   },

--- a/src/__tests__/import-non-relative.js
+++ b/src/__tests__/import-non-relative.js
@@ -1,10 +1,12 @@
 const babel = require('babel-core');
 const content = `
 import type {NamedType} from 'foo';
+import type {NamespaceType} from '@namespace/foo';
 import type DefaultType from 'bar';
 
 type FooProps = {
   an_imported_named_type: NamedType,
+  an_imported_named_namespace_type: NamespaceType,
   an_imported_default_type: DefaultType,
   a_global_type: Date,
   a_undefined_type: FooBarBaz,

--- a/src/index.js
+++ b/src/index.js
@@ -594,7 +594,7 @@ module.exports = function flowReactPropTypes(babel) {
 
         const {node} = path;
 
-        if (/^\w/.test(node.source.value)) return;
+        if (/^@?\w/.test(node.source.value)) return;
 
         // https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/62
         // if (node.source.value[0] !== '.') {


### PR DESCRIPTION
Updates the node_modules regex to also catch namespaces, e.g. `@namespace/foo`.