### PR TITLE
Handle explicit proptypes and default props

### DIFF
--- a/src/__tests__/__snapshots__/class-single-type-test.js.snap
+++ b/src/__tests__/__snapshots__/class-single-type-test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class-single-type-anon-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+
+var _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
+  }
+
+  return _class;
+}(React.Component);
+
+_class.propTypes = {
+  a_number: _propTypes2.default.number.isRequired
+};
+exports.default = _class;"
+`;
+
 exports[`class-single-type-test 1`] = `
 "'use strict';
 

--- a/src/__tests__/__snapshots__/explicit-prop-types-merge-test.js.snap
+++ b/src/__tests__/__snapshots__/explicit-prop-types-merge-test.js.snap
@@ -1,0 +1,302 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`explicit-prop-types-merge-alternate-class-style 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c,
+        this.props.d
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.string,
+  c: _propTypes2.default.string.isRequired,
+  d: _propTypes2.default.string
+};
+exports.default = Foo;"
+`;
+
+exports[`explicit-prop-types-merge-class-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c,
+        this.props.d
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.string,
+  c: _propTypes2.default.string.isRequired,
+  d: _propTypes2.default.string
+};
+exports.default = Foo;"
+`;
+
+exports[`explicit-prop-types-merge-mixed-static 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c,
+        this.props.d
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.string,
+  c: _propTypes2.default.string.isRequired,
+  d: _propTypes2.default.string
+};
+exports.default = Foo;"
+`;
+
+exports[`explicit-prop-types-merge-no-flow-type-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function Foo(props) {
+  return React.createElement(
+    'div',
+    null,
+    props.b,
+    props.d
+  );
+};
+
+Foo.propTypes = {
+  b: PropTypes.string,
+  d: PropTypes.string
+};
+
+exports.default = Foo;"
+`;
+
+exports[`explicit-prop-types-merge-opt-out-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c,
+        this.props.d
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  b: _propTypes2.default.string,
+  d: _propTypes2.default.string
+};
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+exports.default = Foo;"
+`;
+
+exports[`explicit-prop-types-merge-stateless-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var React = require('react');
+
+var Foo = function Foo(props) {
+  return React.createElement(
+    'div',
+    null,
+    props.a,
+    props.b,
+    props.c,
+    props.d
+  );
+};
+
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.string,
+  c: _propTypes2.default.string.isRequired,
+  d: _propTypes2.default.string
+};
+exports.default = Foo;"
+`;

--- a/src/__tests__/__snapshots__/hoc.js.snap
+++ b/src/__tests__/__snapshots__/hoc.js.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`hoc-handles-anon-class-return 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _propTypes = require(\\"prop-types\\");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+exports.default = function () {
+  var _class, _temp;
+
+  return _temp = _class = function (_React$Component) {
+    _inherits(_class, _React$Component);
+
+    function _class() {
+      _classCallCheck(this, _class);
+
+      return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
+    }
+
+    return _class;
+  }(React.Component), _class.propTypes = {
+    a_prop: _propTypes2.default.bool.isRequired
+  }, _temp;
+};"
+`;
+
 exports[`import-object 1`] = `
 "\\"use strict\\";
 

--- a/src/__tests__/__snapshots__/optional-default-props-test.js.snap
+++ b/src/__tests__/__snapshots__/optional-default-props-test.js.snap
@@ -1,0 +1,282 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`optional-default-props-class-merge-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.defaultProps = {
+  a: 7
+};
+Foo.propTypes = {
+  a: _propTypes2.default.string,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+exports.default = Foo;"
+`;
+
+exports[`optional-default-props-class-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.defaultProps = {
+  a: 7
+};
+Foo.propTypes = {
+  a: _propTypes2.default.number,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+exports.default = Foo;"
+`;
+
+exports[`optional-default-props-mixed 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.propTypes = {
+  a: _propTypes2.default.number,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+
+
+Foo.defaultProps = {
+  a: 7
+};
+
+exports.default = Foo;"
+`;
+
+exports[`optional-default-props-opt-out-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        null,
+        this.props.a,
+        this.props.b,
+        this.props.c
+      );
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+Foo.defaultProps = {
+  a: 7
+};
+Foo.propTypes = {
+  a: _propTypes2.default.number.isRequired,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+exports.default = Foo;"
+`;
+
+exports[`optional-default-props-stateless-test 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var Foo = function Foo(props) {
+  return React.createElement(
+    'div',
+    null,
+    props.a,
+    props.b,
+    props.c
+  );
+};
+
+Foo.propTypes = {
+  a: _propTypes2.default.number,
+  b: _propTypes2.default.number.isRequired,
+  c: _propTypes2.default.string.isRequired
+};
+Foo.defaultProps = {
+  a: 7
+};
+
+exports.default = Foo;"
+`;

--- a/src/__tests__/class-single-type-test.js
+++ b/src/__tests__/class-single-type-test.js
@@ -18,3 +18,23 @@ it('class-single-type-test', () => {
   }).code;
   expect(res).toMatchSnapshot();
 });
+
+const contentB = `
+var React = require('react');
+
+type FooProps = {
+  a_number: number,
+}
+
+export default class extends React.Component<FooProps> {
+}
+`;
+
+it('class-single-type-anon-test', () => {
+  const res = babel.transform(contentB, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/explicit-prop-types-merge-test.js
+++ b/src/__tests__/explicit-prop-types-merge-test.js
@@ -1,0 +1,181 @@
+const babel = require('babel-core');
+
+const run = (content, opts) => () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', [require('../'), opts]]
+  }).code;
+  expect(res).toMatchSnapshot();
+};
+
+it('explicit-prop-types-merge-class-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+export default class Foo extends React.Component<FooProps> {
+  static propTypes = {
+    b: PropTypes.string,
+    d: PropTypes.string
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+        {this.props.d}
+      </div>
+    );
+  }
+}
+`, { mergeExplicitPropTypes: true }));
+
+it('explicit-prop-types-merge-opt-out-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+export default class Foo extends React.Component<FooProps> {
+  static propTypes = {
+    b: PropTypes.string,
+    d: PropTypes.string
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+        {this.props.d}
+      </div>
+    );
+  }
+}
+`, { mergeExplicitPropTypes: false }));
+
+it('explicit-prop-types-merge-stateless-test', run(`
+var React = require('react');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+const Foo = (props: FooProps) => {
+  return (
+    <div>
+      {props.a}
+      {props.b}
+      {props.c}
+      {props.d}
+    </div>
+  );
+};
+
+Foo.propTypes = {
+  b: PropTypes.string,
+  d: PropTypes.string
+};
+
+export default Foo;
+`, { mergeExplicitPropTypes: true }));
+
+it('explicit-prop-types-merge-no-flow-type-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+const Foo = props => {
+  return (
+    <div>
+      {props.b}
+      {props.d}
+    </div>
+  );
+};
+
+Foo.propTypes = {
+  b: PropTypes.string,
+  d: PropTypes.string
+};
+
+export default Foo;
+`, { mergeExplicitPropTypes: true }));
+
+it('explicit-prop-types-merge-mixed-static', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component<FooProps> {
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+        {this.props.d}
+      </div>
+    );
+  }
+}
+
+Foo.propTypes = {
+  b: PropTypes.string,
+  d: PropTypes.string
+};
+
+export default Foo;
+`, { mergeExplicitPropTypes: true }));
+
+it('explicit-prop-types-merge-alternate-class-style', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component {
+  props: FooProps
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+        {this.props.d}
+      </div>
+    );
+  }
+}
+
+Foo.propTypes = {
+  b: PropTypes.string,
+  d: PropTypes.string
+};
+
+export default Foo;
+`, { mergeExplicitPropTypes: true }));

--- a/src/__tests__/hoc.js
+++ b/src/__tests__/hoc.js
@@ -20,3 +20,24 @@ it('import-object', () => {
   }).code;
   expect(res).toMatchSnapshot();
 });
+
+const contentB = `
+type FooProps = {
+  a_prop: boolean,
+};
+
+export default () => {
+  return class extends React.Component {
+    props: FooProps;
+  }
+};
+`;
+
+it('hoc-handles-anon-class-return', () => {
+  const res = babel.transform(contentB, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/optional-default-props-test.js
+++ b/src/__tests__/optional-default-props-test.js
@@ -1,0 +1,157 @@
+const babel = require('babel-core');
+
+const run = (content, opts) => () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', [require('../'), opts]]
+  }).code;
+  expect(res).toMatchSnapshot();
+};
+
+it('optional-default-props-class-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component<FooProps> {
+  static defaultProps = {
+    a: 7
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+      </div>
+    );
+  }
+}
+
+export default Foo;
+`, { defaultPropsOptional: true }));
+
+it('optional-default-props-stateless-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+const Foo = (props: FooProps) => {
+  return (
+    <div>
+      {props.a}
+      {props.b}
+      {props.c}
+    </div>
+  );
+}
+
+Foo.defaultProps = {
+  a: 7
+};
+
+export default Foo;
+`, { defaultPropsOptional: true }));
+
+it('optional-default-props-mixed', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component<FooProps> {
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+      </div>
+    );
+  }
+}
+
+Foo.defaultProps = {
+  a: 7
+};
+
+export default Foo;
+`, { defaultPropsOptional: true }));
+
+it('optional-default-props-class-merge-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component<FooProps> {
+  static defaultProps = {
+    a: 7
+  }
+
+  static propTypes = {
+    a: PropTypes.string
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+      </div>
+    );
+  }
+}
+
+export default Foo;
+`, { defaultPropsOptional: true, mergeExplicitPropTypes: true }));
+
+it('optional-default-props-opt-out-test', run(`
+var React = require('react');
+var PropTypes = require('prop-types');
+
+type FooProps = {
+  a: number,
+  b: number,
+  c: string,
+}
+
+class Foo extends React.Component<FooProps> {
+  static defaultProps = {
+    a: 7
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.a}
+        {this.props.b}
+        {this.props.c}
+      </div>
+    );
+  }
+}
+
+export default Foo;
+`, { defaultPropsOptional: false }));

--- a/src/index.js
+++ b/src/index.js
@@ -302,6 +302,26 @@ module.exports = function flowReactPropTypes(babel) {
     return mergedPropTypes;
   };
 
+  const setDefaultPropsOptional = (generatedProperties, path, name) => {
+    const [defaultPropNode] =
+      findPresetProperties(path, name, 'defaultProps');
+
+    if (!defaultPropNode || !defaultPropNode.properties) {
+      return generatedProperties;
+    }
+
+    const defaultProps =
+      defaultPropNode.properties.map(prop => prop.key.name);
+
+    return generatedProperties.map(prop => {
+      if (defaultProps.includes(prop.key)) {
+        prop.value.isRequired = false;
+      }
+
+      return prop;
+    });
+  };
+
     /**
      * Adds propTypes or contextTypes annotations to code
      *
@@ -406,6 +426,11 @@ module.exports = function flowReactPropTypes(babel) {
     }
 
     if (propsOrVar) {
+      if (opts.defaultPropsOptional && propsOrVar.properties) {
+        propsOrVar.properties =
+          setDefaultPropsOptional(propsOrVar.properties, targetPath, name);
+      }
+
       addAnnotationsToAST(targetPath, name, 'propTypes', propsOrVar);
     }
 


### PR DESCRIPTION
Great project! This PR combines 2 things my company needed for our codebase. I included as separate commits under a single PR for ease of initial discussion. I'm happy to split it up, or drop parts, based on feedback.

Issue 1: Explicitly defined proptypes (9fc0875)
- If someone decides to add explicit proptypes for whatever reason, I think it makes sense to prioritize that. Currently the plugin adds a duplicate propType declaration (`X.proptypes = {}; X.propTypes = {};`), if a component also defines prop types.
- This is useful if (1) the plugin doesn't handle something, and we want to provide it manually; and (2) for special case prop types, like wrapping with a deprecated prop type log. 
- This is opt in, with `mergeExplicitPropTypes` 

Issue 2: Default props optional (e968b5c)
- If someone sets `defaultProps` for a component, it is not a flow error to call that component without passing passing in props manually (flow picks up on the defaultProps). However, this plugin marks the propTypes as `isRequired`, regardless of `defaultProps`. This can result in discrepancies based on falsy values.
- This makes defaultProps optional, and is opt in with `defaultPropsOptional`.

Issue 3: Anonymous classes in hocs: This was fixed by 20.1.0 as well (thanks!), so I undid my changes, but left in my specs, if helpful.