### PR TITLE
fixes error for spread on imported type, resolves #204

### DIFF
--- a/src/__tests__/__snapshots__/imported-spread-test.js.snap
+++ b/src/__tests__/__snapshots__/imported-spread-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`imported-spread 1`] = `
+"'use strict';
+
+var _other_module = require('./other_module');
+
+var React = require('react');"
+`;

--- a/src/__tests__/imported-spread-test.js
+++ b/src/__tests__/imported-spread-test.js
@@ -1,0 +1,24 @@
+const babel = require('babel-core');
+const content = `
+var React = require('react');
+import { type Foo } from './other_module';
+
+type Props = {|
+  id: string,
+  ...Foo,
+|}
+`;
+
+it('imported-spread', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['es2015', 'stage-1', 'react'],
+    plugins: ['syntax-flow', require('../')],
+  }).code;
+  
+  // The type shouldn't show up as we don't support
+  // spreads from imports
+  expect(res).not.toMatch(/Foo/);
+
+  expect(res).toMatchSnapshot();
+});

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -166,6 +166,11 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     }
 
     const spreadShape = convertToPropTypes(subnode, importedTypes, internalTypes);
+
+    if (spreadShape.type === 'raw') {
+      return [];
+    }
+
     const properties = spreadShape.properties;
 
     // Unless or until the strange default behavior changes in flow (https://github.com/facebook/flow/issues/3214)


### PR DESCRIPTION
Minimal example, where we import a type, and then try to spread it:

```js
import { type Foo } from './Foo';

export type Something = {
   ...Foo,
}
```

This change causes it not to error, however we just eliminate the spread for now.

To actually support this, we'd need to wrap the spread type in a custom fake propTypes function, like this:

```js
const bpfrpt_proptype_Something = {
  __made_up_prop: (...args) => {
    // apply `bpfrpt_proptype_Foo` to the props object
  }
}
```

If anyone wants to try implementing this and has time to test it well, that'd be great.