### PR TITLE
handle EmptyTypeAnnotations

### DIFF
--- a/src/__tests__/__snapshots__/empty-test.js.snap
+++ b/src/__tests__/__snapshots__/empty-test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty 1`] = `
+"\\"use strict\\";
+
+function _typeof(obj) { if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === \\"object\\" || typeof call === \\"function\\")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function\\"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return self; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var Foo =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    var _getPrototypeOf2;
+
+    var _this;
+
+    _classCallCheck(this, Foo);
+
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Foo)).call.apply(_getPrototypeOf2, [this].concat(args)));
+
+    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), \\"props\\", void 0);
+
+    return _this;
+  }
+
+  _createClass(Foo, [{
+    key: \\"render\\",
+    value: function render() {
+      return React.createElement(\\"div\\", null);
+    }
+  }]);
+
+  return Foo;
+}(React.Component);
+
+;"
+`;

--- a/src/__tests__/__snapshots__/empty-test.js.snap
+++ b/src/__tests__/__snapshots__/empty-test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`empty 1`] = `"\\"use strict\\";"`;

--- a/src/__tests__/__snapshots__/empty-test.js.snap
+++ b/src/__tests__/__snapshots__/empty-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty 1`] = `"\\"use strict\\";"`;

--- a/src/__tests__/empty-test.js
+++ b/src/__tests__/empty-test.js
@@ -6,7 +6,7 @@ type Empty = {
 `;
 
 it('empty', () => {
-  const res = babel.transform(content, {
+  expect(() => babel.transform(content, {
     babelrc: false,
     presets: ['@babel/env', '@babel/react', '@babel/flow'],
     plugins: [
@@ -14,6 +14,5 @@ it('empty', () => {
       require('../'),
       "@babel/plugin-proposal-class-properties"
     ],
-  }).code;
-  expect(res).toMatchSnapshot();
+  }).code).not.toThrow();
 });

--- a/src/__tests__/empty-test.js
+++ b/src/__tests__/empty-test.js
@@ -1,0 +1,19 @@
+const babel = require('babel-core');
+const content = `
+type Empty = {
+    [key: string]: empty,
+};
+`;
+
+it('empty', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['@babel/env', '@babel/react', '@babel/flow'],
+    plugins: [
+      '@babel/syntax-flow',
+      require('../'),
+      "@babel/plugin-proposal-class-properties"
+    ],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/empty-test.js
+++ b/src/__tests__/empty-test.js
@@ -1,12 +1,18 @@
 const babel = require('babel-core');
 const content = `
 type Empty = {
-    [key: string]: empty,
+    impossibleProp: empty,
+};
+
+class Foo extends React.Component {
+  props: FooProps;
+
+  render() { return <div /> }
 };
 `;
 
 it('empty', () => {
-  expect(() => babel.transform(content, {
+  const res = babel.transform(content, {
     babelrc: false,
     presets: ['@babel/env', '@babel/react', '@babel/flow'],
     plugins: [
@@ -14,5 +20,6 @@ it('empty', () => {
       require('../'),
       "@babel/plugin-proposal-class-properties"
     ],
-  }).code).not.toThrow();
+  }).code;
+  expect(res).toMatchSnapshot();
 });

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -360,6 +360,10 @@ export default function convertToPropTypes(node, importedTypes, internalTypes) {
     }
     resultPropType = {type: 'oneOf', options: [value]};
   }
+  else if (node.type === 'EmptyTypeAnnotation') {
+    // empty types are impossible to satisfy as are oneOfType's without any options
+    resultPropType = {type: 'oneOfType', optional: node.optional, options: []};
+  }
 
   if (resultPropType) {
     return resultPropType;


### PR DESCRIPTION
The plugin traverses all type annotations even those that aren't used for props.  This diff updates the plugin to handle `empty` types. 