### PR TITLE
Fix #215

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "cross-env BABEL_ENV=production babel src/ --out-dir lib/ --ignore src/__tests__ --presets @babel/env,@babel/react",
     "predeploy": "npm run build && npm run lint",
     "prepublish": "npm run build && npm run lint",
-    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
+    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/__snapshots__/import-with-private-class-test.js.snap
+++ b/src/__tests__/__snapshots__/import-with-private-class-test.js.snap
@@ -86,7 +86,7 @@ function (_React$Component2) {
 
 exports.default = TableOfContentsRowWithQuery;
 
-_defineProperty(TableOfContentsRowWithQuery, \\"propTypes\\", Object.assign({}, bpfrpt_proptype_RowProps === _propTypes.default.any ? {} : _otherRow.bpfrpt_proptype_RowProps, {
+_defineProperty(TableOfContentsRowWithQuery, \\"propTypes\\", Object.assign({}, _otherRow.bpfrpt_proptype_RowProps === _propTypes.default.any ? {} : _otherRow.bpfrpt_proptype_RowProps, {
   domain: _propTypes.default.string.isRequired
 }));"
 `;

--- a/src/__tests__/__snapshots__/import-with-private-class-test.js.snap
+++ b/src/__tests__/__snapshots__/import-with-private-class-test.js.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import-object 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports.default = void 0;
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _otherRow = require(\\"./other-row.jsx\\");
+
+var _propTypes = _interopRequireDefault(require(\\"prop-types\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+function _typeof(obj) { if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === \\"object\\" || typeof call === \\"function\\")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function\\"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var TableOfContentsRow =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(TableOfContentsRow, _React$Component);
+
+  function TableOfContentsRow() {
+    _classCallCheck(this, TableOfContentsRow);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(TableOfContentsRow).apply(this, arguments));
+  }
+
+  _createClass(TableOfContentsRow, [{
+    key: \\"render\\",
+    value: function render() {
+      return React.createElement(\\"div\\", null, \\"I'm a row\\");
+    }
+  }]);
+
+  return TableOfContentsRow;
+}(React.Component);
+
+_defineProperty(TableOfContentsRow, \\"propTypes\\", Object.assign({}, _otherRow.bpfrpt_proptype_RowProps === _propTypes.default.any ? {} : _otherRow.bpfrpt_proptype_RowProps, {
+  domain: _propTypes.default.string.isRequired
+}));
+
+var TableOfContentsRowWithQuery =
+/*#__PURE__*/
+function (_React$Component2) {
+  _inherits(TableOfContentsRowWithQuery, _React$Component2);
+
+  function TableOfContentsRowWithQuery() {
+    _classCallCheck(this, TableOfContentsRowWithQuery);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(TableOfContentsRowWithQuery).apply(this, arguments));
+  }
+
+  _createClass(TableOfContentsRowWithQuery, [{
+    key: \\"render\\",
+    value: function render() {
+      return React.createElement(TableOfContentsRow, null);
+    }
+  }]);
+
+  return TableOfContentsRowWithQuery;
+}(React.Component);
+
+exports.default = TableOfContentsRowWithQuery;
+
+_defineProperty(TableOfContentsRowWithQuery, \\"propTypes\\", Object.assign({}, bpfrpt_proptype_RowProps === _propTypes.default.any ? {} : _otherRow.bpfrpt_proptype_RowProps, {
+  domain: _propTypes.default.string.isRequired
+}));"
+`;

--- a/src/__tests__/__snapshots__/intersection-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-complex-example.js.snap
@@ -126,12 +126,12 @@ _defineProperty(D, \\"propTypes\\", Object.assign({}, {
   b: function b() {
     return (typeof _types.bpfrpt_proptype_NamedType === \\"function\\" ? _types.bpfrpt_proptype_NamedType.isRequired ? _types.bpfrpt_proptype_NamedType.isRequired : _types.bpfrpt_proptype_NamedType : _propTypes.default.shape(_types.bpfrpt_proptype_NamedType).isRequired).apply(this, arguments);
   }
-}, Object.assign({}, bpfrpt_proptype_NamedType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_NamedType, {
+}, Object.assign({}, _types.bpfrpt_proptype_NamedType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_NamedType, {
   a: function a() {
     return (typeof _types.bpfrpt_proptype_NamedType === \\"function\\" ? _types.bpfrpt_proptype_NamedType.isRequired ? _types.bpfrpt_proptype_NamedType.isRequired : _types.bpfrpt_proptype_NamedType : _propTypes.default.shape(_types.bpfrpt_proptype_NamedType).isRequired).apply(this, arguments);
   },
   b: _propTypes.default.string.isRequired
-}, bpfrpt_proptype_DefaultType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_DefaultType, {
+}, _types.bpfrpt_proptype_DefaultType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_DefaultType, {
   bar: _propTypes.default.number.isRequired
 }, {
   foo: _propTypes.default.string.isRequired

--- a/src/__tests__/__snapshots__/intersection-export-test.js.snap
+++ b/src/__tests__/__snapshots__/intersection-export-test.js.snap
@@ -63,7 +63,7 @@ function (_React$Component) {
   return C;
 }(React.Component);
 
-_defineProperty(C, \\"propTypes\\", Object.assign({}, bpfrpt_proptype_T === _propTypes.default.any ? {} : _T.bpfrpt_proptype_T, {
+_defineProperty(C, \\"propTypes\\", Object.assign({}, _T.bpfrpt_proptype_T === _propTypes.default.any ? {} : _T.bpfrpt_proptype_T, {
   foo: _propTypes.default.string.isRequired
 }));
 

--- a/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
+++ b/src/__tests__/__snapshots__/intersection-nested-complex-example.js.snap
@@ -63,7 +63,7 @@ function (_React$Component) {
   return D;
 }(React.Component);
 
-_defineProperty(D, \\"propTypes\\", Object.assign({}, Object.assign({}, bpfrpt_proptype_NamedType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_NamedType, {
+_defineProperty(D, \\"propTypes\\", Object.assign({}, Object.assign({}, _types.bpfrpt_proptype_NamedType === _propTypes.default.any ? {} : _types.bpfrpt_proptype_NamedType, {
   a: _propTypes.default.string.isRequired
 }), {
   c: _propTypes.default.string.isRequired

--- a/src/__tests__/import-with-private-class-test.js
+++ b/src/__tests__/import-with-private-class-test.js
@@ -1,0 +1,35 @@
+const babel = require('babel-core');
+const content = `
+import * as React from "react";
+
+import type {RowProps} from "./other-row.jsx";
+
+type StaticProps = RowProps & {
+    domain: string,
+};
+
+class TableOfContentsRow extends React.Component<StaticProps> {
+    render() {
+        return <div>I'm a row</div>;
+    }
+}
+
+export default class TableOfContentsRowWithQuery extends React.Component<StaticProps> {
+    render() {
+        return <TableOfContentsRow/>;
+    }
+}
+`;
+
+it('import-object', () => {
+  const res = babel.transform(content, {
+    babelrc: false,
+    presets: ['@babel/env', '@babel/react', '@babel/flow'],
+    plugins: [
+      '@babel/syntax-flow',
+      require('../'),
+      "@babel/plugin-proposal-class-properties"
+    ],
+  }).code;
+  expect(res).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -367,7 +367,9 @@ module.exports = function flowReactPropTypes(babel) {
         return;
       }
 
-      valueNode = propTypesAST;
+      // Clone the props node so that we don't use the same node in multiple
+      // parts of the same AST.
+      valueNode = JSON.parse(JSON.stringify(propTypesAST));
       if (attribute === 'propTypes') {
         valueNode = wrapInDceCheck(valueNode);
         if (valueNode.properties) {
@@ -599,9 +601,7 @@ module.exports = function flowReactPropTypes(babel) {
             return;
           }
 
-          // Clone the props node so that we don't use the same node in multiple
-          // parts of the same AST.
-          propTypes = JSON.parse(JSON.stringify(props));
+          propTypes = props;
         }
 
         if (secondSuperParam && (secondSuperParam.type === 'ObjectTypeAnnotation' || secondSuperParam.type === 'IntersectionTypeAnnotation')) {

--- a/src/index.js
+++ b/src/index.js
@@ -599,7 +599,9 @@ module.exports = function flowReactPropTypes(babel) {
             return;
           }
 
-          propTypes = props;
+          // Clone the props node so that we don't use the same node in multiple
+          // parts of the same AST.
+          propTypes = JSON.parse(JSON.stringify(props));
         }
 
         if (secondSuperParam && (secondSuperParam.type === 'ObjectTypeAnnotation' || secondSuperParam.type === 'IntersectionTypeAnnotation')) {


### PR DESCRIPTION
In some situations where imported prop types were being used in multiple components, some of the AST nodes generated by the plugin were being used in multiple places which caused issues for downstream plugins in `@babel/env`.  This PR fixes that by clone the prop types node before adding it to the AST.

<sub>Resolves #215</sub> <!-- edited for auto-close of the issue -->