### PR TITLE
Remove extra quotes for StringLiterals

### DIFF
--- a/src/__tests__/__snapshots__/string-literal-property.js.snap
+++ b/src/__tests__/__snapshots__/string-literal-property.js.snap
@@ -13,7 +13,7 @@ var _propTypes = _interopRequireDefault(require(\\"prop-types\\"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var bpfrpt_proptype_T = {
-  \\"read-only\\": _propTypes.default.oneOf([true]).isRequired,
+  read-only: _propTypes.default.oneOf([true]).isRequired,
   regular: _propTypes.default.oneOf([true]).isRequired
 };
 exports.bpfrpt_proptype_T = bpfrpt_proptype_T;"

--- a/src/convertToPropTypes.js
+++ b/src/convertToPropTypes.js
@@ -2,7 +2,7 @@ import {$debug, isExact, PLUGIN_NAME} from './util';
 
 function getObjectTypePropertyKey(node) {
   if (node.key.type === 'StringLiteral') {
-    return `"${node.key.value}"`;
+    return node.key.value;
   }
   return node.key.name;
 }


### PR DESCRIPTION
Addresses the issue brought up here https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/219

Currently extra quotes are added to StringLiteral props, commonly `data-cy` and `aria-label`.

Example component
```js
// @flow
import * as React from 'react';
import ReactDOM from 'react-dom';

type Props = {|
	'data-cy': string,
|};
function MyComponent(props: Props) {
	const { 'data-cy': dataCy } = props;
	return <div data-cy={dataCy}>hello</div>;
}

const root = document.getElementById('react-root');
if (!root) throw new Error('Could not find react dom root');
ReactDOM.render(<MyComponent data-cy="aDataCyTest" />, root);
```

Currently, the above `Props` are transpiled into:
```js
MyComponent.propTypes = {
  "\"data-cy\"": prop_types__WEBPACK_IMPORTED_MODULE_2___default.a.string.isRequired
};
```

This works as long as the place we use it passes in `data-cy` directly:
```js
return <div data-cy={dataCy}>hello</div>;
```

However for a lot of common components, props are just passed through:
```js
return <div {...props}>hello</div>;
```

And in this case since `"data-cy"` is passed in instead of `data-cy` we get an error in the console:
![image](https://user-images.githubusercontent.com/1386713/82693722-3c6e4400-9c1f-11ea-9785-df5a46692a71.png)

The work around would be to just pass in each prop directly as mentioned above, but it's not really feasible when using a 3rd party lib and it's hacky when passing an object type and having to destructure off StringLiteral props so that they don't have extra quotes concatenated.

This PR just removes the extra quotes.